### PR TITLE
add playbook validation tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+install: |
+  pip install tox
+script: |
+  tox
+addons:
+  apt:
+    packages:
+      - libffi-dev
+      - libssl-dev
+      - libyaml-dev

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # opstools-ansible
 Ansible playbooks for deploying OpsTools
+
+## Running tests
+
+You can run simple YAML validation tests by running:
+
+    tox

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,9 @@
+# For debian/ubuntu environments
+libffi-dev [platform:dpkg]
+libssl-dev [platform:dpkg]
+libyaml-dev [platform:dpkg]
+
+# for rhel/centos/fedora
+libffi-devel [platform:rpm]
+openssl-devel [platform:rpm]
+libyaml-devel [platform:rpm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,29 @@
+[metadata]
+name = opstools-ansible
+summary = opstools-ansible - ansible playbooks for installing OpenStack operational tools
+description-file =
+    README.md
+author = opstools-ansible contributors
+home-page = https://github.com/centos-opstools/opstools-ansible
+classifier =
+  License :: OSI Approved :: Apache Software License
+  Development Status :: 4 - Beta
+  Intended Audience :: Developers
+  Intended Audience :: System Administrators
+  Intended Audience :: Information Technology
+  Topic :: Utilities
+
+[global]
+setup-hooks =
+    pbr.hooks.setup_hook
+
+[files]
+data_files =
+    usr/local/share/opstools-ansible/roles = roles/*
+
+[wheel]
+universal = 1
+
+[pbr]
+skip_authors = True
+skip_changelog = True

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+#   Copyright Red Hat, Inc. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+import setuptools
+
+setuptools.setup(
+    setup_requires=['pbr'],
+    pbr=True)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+ansible-lint

--- a/tools/validate-playbooks
+++ b/tools/validate-playbooks
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+find * -name templates -prune -o \
+	\( -name '*.yml' -o -name '*.yaml' \) \
+	-exec ansible-lint -v -x ANSIBLE0006 {} \;

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+minversion = 1.6
+envlist = linters
+skipdist = True
+
+[testenv]
+usedevelop = True
+install_command = pip install -U {opts} {packages}
+setenv = VIRTUAL_ENV={envdir}
+deps = -r{toxinidir}/test-requirements.txt
+
+[testenv:linters]
+commands =
+  {toxinidir}/tools/validate-playbooks
+
+[testenv:bindep]
+deps = bindep
+commands = bindep test


### PR DESCRIPTION
this change adds a tox configuration that installs and runs
ansible-lint on all our `*.yaml` and `*.yml` files (excluding those in
`templates/` directories, which may contain jinja markup that would
prevent validation).

this change also contains a `.travis.yml` file that will permit us to
enable automatic tests on incoming pull requests.
