### PR TITLE
Feature/fluentd listen syslog

### DIFF
--- a/roles/fluentd/elasticsearch/templates/elasticsearch.conf
+++ b/roles/fluentd/elasticsearch/templates/elasticsearch.conf
@@ -9,7 +9,7 @@
   # required by kibana
   logstash_format true
 
-{% for k, v in fluentd_elasticsearch_extraconfig|default({}) %}
+{% for k, v in (fluentd_elasticsearch_extraconfig|default({})).items() %}
   {{k}} {{v}}
 {% endfor %}
 </match>

--- a/roles/fluentd/server/templates/listen_no_ssl.conf
+++ b/roles/fluentd/server/templates/listen_no_ssl.conf
@@ -8,7 +8,7 @@
   bind {{ fluentd_bind_address }}
 {% endif %}
 
-{% for k, v in fluentd_server_extraconfig|default({}) %}
+{% for k, v in (fluentd_server_extraconfig|default({})).items() %}
   {{k}} {{v}}
 {% endfor %}
 </source>

--- a/roles/fluentd/server/templates/listen_ssl.conf
+++ b/roles/fluentd/server/templates/listen_ssl.conf
@@ -16,7 +16,7 @@
   bind {{ fluentd_bind_address }}
 {% endif %}
 
-{% for k, v in fluentd_server_extraconfig|default({}) %}
+{% for k, v in (fluentd_server_extraconfig|default({})).items() %}
   {{k}} {{v}}
 {% endfor %}
 </source>

--- a/roles/fluentd/syslog/defaults/main.yml
+++ b/roles/fluentd/syslog/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+fluentd_syslog_port: 5140
+fluentd_syslog_bind_address: 127.0.0.1
+fluentd_syslog_tag: system.messages

--- a/roles/fluentd/syslog/meta/main.yml
+++ b/roles/fluentd/syslog/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - rsyslog
+  - fluentd

--- a/roles/fluentd/syslog/tasks/main.yml
+++ b/roles/fluentd/syslog/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: install fluentd rsyslog config
+  template:
+    src: rsyslog.conf
+    dest: '{{ rsyslog_config_dir }}/fluentd.conf'
+  notify: restart rsyslogd
+
+- name: install fluentd syslog source
+  template:
+    src: listen-syslog.conf
+    dest: '{{ fluentd_config_parts_dir }}/100-listen-rsyslog.conf'
+  notify: restart fluentd

--- a/roles/fluentd/syslog/templates/listen-syslog.conf
+++ b/roles/fluentd/syslog/templates/listen-syslog.conf
@@ -1,0 +1,8 @@
+<source>
+  @type syslog
+  port {{ fluentd_syslog_port }}
+{% if fluentd_syslog_bind_address is defined %}
+  bind {{ fluentd_syslog_bind_address }}
+{% endif %}
+  tag {{ fluentd_syslog_tag }}
+</source>

--- a/roles/fluentd/syslog/templates/rsyslog.conf
+++ b/roles/fluentd/syslog/templates/rsyslog.conf
@@ -1,0 +1,1 @@
+*.* @{{ fluentd_syslog_bind_address }}:{{ fluentd_syslog_port }}

--- a/roles/fluentd/tasks/main.yml
+++ b/roles/fluentd/tasks/main.yml
@@ -45,4 +45,4 @@
     name: '{{ fluentd_service_name }}'
     state: running
     enabled: true
-  when: manages_services|default(false)
+  when: manage_services|default(false)

--- a/roles/rsyslog/defaults/main.yml
+++ b/roles/rsyslog/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+rsyslog_config_dir: /etc/rsyslog.d

--- a/roles/rsyslog/handlers/main.yml
+++ b/roles/rsyslog/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart rsyslogd
+  service:
+    name: rsyslog
+    state: restarted


### PR DESCRIPTION
add config for forwarding syslog messages to fluentd

this role configures fluentd to receive syslog messages, and drops an rsyslog configuration in place to forward all syslog messages to fluentd.
