### PR TITLE
make grafana role follow common patterns

### DIFF
--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -2,3 +2,6 @@
 graphite_listen_port: 8080
 
 grafana_port: 3000
+
+grafana_package_name: grafana
+grafana_service_name: grafana-server

--- a/roles/grafana/tasks/grafana.yml
+++ b/roles/grafana/tasks/grafana.yml
@@ -1,16 +1,16 @@
 ---
 - name: install grafana
   yum:
-      name: '{{ item }}'
+      name: '{{ grafana_package_name }}'
       state: present
-  with_items:
-      - grafana
+  when: manage_packages|default(false)
 
 - name: enable grafana
   service:
-      name: grafana-server
+      name: '{{ grafana_service_name }}'
       state: started
       enabled: yes
+  when: manage_services|default(false)
 
 - name: insert firewalld rule for grafana
   set_fact:


### PR DESCRIPTION
listen for conditionals on install and service
enablement. Add a variable for the package name
and the service name.
