### PR TITLE
add profile roles

### DIFF
--- a/roles/profiles/allinone/meta/main.yml
+++ b/roles/profiles/allinone/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - profiles/logging
+  - profile/availability-monitoring
+  - profile/performance-monitoring

--- a/roles/profiles/availability-monitoring/meta/main.yml
+++ b/roles/profiles/availability-monitoring/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - sensu/server
+  - uchiwa

--- a/roles/profiles/logging/meta/main.yml
+++ b/roles/profiles/logging/meta/main.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+  - elasticsearch
+  - kibana
+  - fluentd/server
+  - fluentd/syslog
+  - fluentd/elasticsearch

--- a/roles/profiles/performance-monitoring/meta/main.yml
+++ b/roles/profiles/performance-monitoring/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - collectd
+  - grafana


### PR DESCRIPTION
these are high-level roles that contain only a "meta" directory. They
compose multiple lower-level roles into a single functional "profile".

These roles won't  currently work because we don't have all the individual service roles merged yet, but I want to use this structure for packaging.
