### PR TITLE
Collectd: Rely on the SELinux ansible facts

### DIFF
--- a/roles/collectd/tasks/main.yml
+++ b/roles/collectd/tasks/main.yml
@@ -20,16 +20,9 @@
       state: started
       enabled: yes
 
-
-- name: test to see if selinux is running
-  command: getenforce
-  register: sestatus
-  changed_when: false
-
 - name: set collectd_tcp_network_connect
   seboolean:
       name: collectd_tcp_network_connect
       state: yes
       persistent: yes
-  when: sestatus.rc != 0 or sestatus.stdout == "Enforcing" or
-      sestatus.stdout == "Permissive"
+  when: '"{{ ansible_selinux.mode }}" in ["enforcing", "permissive"]'


### PR DESCRIPTION
Currently a first task is run to determine the state of SELinux on the
machine. This task is uncesseary as Ansible provide this information as
part of the facts it gathered.

```
"ansible_selinux": {
    "config_mode": "enforcing",
    "mode": "permissive",
    "policyvers": 28,
    "status": "enabled",
    "type": "targeted"
},
```

Hence the decision to enable or not the collectd_tcp_network_connect
boolean should be based on those facts.

For clarification:
- config_mode: is the selinux state written in /etc/selinux/config
- mode: is the selinux state returned by getenforce
