### PR TITLE
Collectd: Standardize the way package mgmt is done

### DIFF
--- a/roles/collectd/defaults/main.yml
+++ b/roles/collectd/defaults/main.yml
@@ -1,4 +1,10 @@
 ---
+collectd_package_name: collectd
+collectd_service_name: collectd
+
 graphite_port: 2003
 graphite_host: localhost
 
+collectd_plugins:
+  - collectd-sensors
+  - collectd-virt

--- a/roles/collectd/handlers/main.yml
+++ b/roles/collectd/handlers/main.yml
@@ -2,5 +2,5 @@
 # restart collectd
 - name: restart collectd
   service:
-      name: collectd
+      name: '{{ collectd_service_name }}'
       state: restarted

--- a/roles/collectd/tasks/main.yml
+++ b/roles/collectd/tasks/main.yml
@@ -1,12 +1,17 @@
 ---
 - name: install collectd
-  yum:
-      name: '{{ item }}'
-      state: present
-  with_items:
-      - collectd
-      - collectd-sensors
-      - collectd-virt
+  package:
+    name: '{{ collectd_package_name }}'
+    state: present
+  when: manage_packages|default(false)
+
+- name: install collectd plugins
+  package:
+    name: '{{ item }}'
+    state: present
+  with_items: '{{ collectd_plugins }}'
+  when: manage_packages|default(false)
+  notify: restart collectd
 
 - name: place write_graphite-config
   template:
@@ -16,9 +21,10 @@
 
 - name: enable collectd
   service:
-      name: collectd
+      name: '{{ collectd_service_name }}'
       state: started
       enabled: yes
+  when: manage_services|default(false)
 
 - name: set collectd_tcp_network_connect
   seboolean:


### PR DESCRIPTION
Looking at other modules in the opstools-ansible repo, it seems that
collectd isn't applying the same pattern as other.

This commit :
- Handles the plugins as a variable
- Understand the `manage_packages` variable
- Understand the `manage_services` variable
- Use a variable for its service name in its handler
