### PR TITLE
Grafana: Enforce the grafana_port at the configuration level

### DIFF
--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -5,3 +5,4 @@ grafana_port: 3000
 
 grafana_package_name: grafana
 grafana_service_name: grafana-server
+grafana_config_file: '/etc/grafana/grafana.ini'

--- a/roles/grafana/handlers/main.yml
+++ b/roles/grafana/handlers/main.yml
@@ -4,3 +4,9 @@
   service:
       name: httpd
       state: restarted
+
+# restart grafana-server
+- name: restart grafana-server
+  service:
+      name: '{{ grafana_service_name }}'
+      state: restarted

--- a/roles/grafana/tasks/grafana.yml
+++ b/roles/grafana/tasks/grafana.yml
@@ -5,6 +5,16 @@
       state: present
   when: manage_packages|default(false)
 
+- name: Configure grafana server section
+  ini_file: dest='{{ grafana_config_file }}'
+            section=server
+            option={{ item.option }}
+            value={{ item.value }}
+            backup=yes
+  with_items:
+    - { option: 'http_port', value: '{{ grafana_port }}' }
+  notify: restart grafana-server
+
 - name: enable grafana
   service:
       name: '{{ grafana_service_name }}'


### PR DESCRIPTION
Currently the grafana_port variable is enforced only at the firewall
level but not at the actual configuration file level, meaning that the
actual change of port wouldn't have the expected result.

This commit ensures the port is also changed at the configuration level.
