### PR TITLE
Redis: Allow Redis to listen on several interface

### DIFF
--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 redis_config_file: /etc/redis.conf
 redis_listen_port: 6379
-redis_interface: 127.0.0.1
+redis_interface:
+  - 127.0.0.1
 
 redis_package_name: redis
 redis_service_name: redis

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -5,31 +5,19 @@
    state: installed
   when: manage_packages|default(false)
 
-- name: Ensure redis config file exits
-  file:
-    path: '{{ redis_config_file }}'
-    state: file
-    owner: '{{ redis_owner }}'
-
 - name: Set listen port at redis config
   replace:
      dest: '{{ redis_config_file }}'
      regexp: '^port.*\n'
      replace: 'port {{ redis_listen_port }}\n'
   notify: Restart redis
-  when: (not redis_listen_port == 6379) or
-        (manage_packages|default(false))
 
 - name: Add bind interface at the redis config
-  lineinfile:
+  replace:
      dest: '{{ redis_config_file }}'
-     create: yes
-     state: present
-     insertafter: 'bind 127.0.0.1'
-     line: 'bind {{ redis_interface }}'
+     regexp: '^bind.*\n'
+     replace: 'bind {{ " ".join(redis_interface) }}\n'
   notify: Restart redis
-  when: (not redis_interface == '127.0.0.1') or
-        (manage_packages|default(false))
 
 - name: Ensure redis is started and enabled at boot
   service:
@@ -42,4 +30,3 @@
   set_fact:
     firewall_ports: >
       {{ firewall_ports + [redis_listen_port] }}
-  when: not redis_interface == '127.0.0.1'


### PR DESCRIPTION
As it is right now, Redis can only listen to one interface. This commit
adds the flexibility for Redis to be able to listen on various
interfaces.

Also the tasks ensuring `/etc/redis.conf` has been removed as:

```
[root@opstools-packaging centos]# rpm -ql redis                                      
/etc/logrotate.d/redis
/etc/redis-sentinel.conf
/etc/redis.conf
```
