### PR TITLE
RabbitMQ: Allow one to specify interface and port

### DIFF
--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 rabbitmq_port: 5672
 rabbitmq_server: localhost
+rabbitmq_interface:
+  - 127.0.0.1
+  - ::1
 
 rabbitmq_service_name: rabbitmq-server
 rabbitmq_package_name: rabbitmq-server
+rabbitmq_config_file: /etc/rabbitmq/rabbitmq.config

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -5,6 +5,14 @@
    state: present
   when: manage_packages|default(false)
 
+- name: Enforce port and interface configuration
+  lineinfile:
+    dest: '{{ rabbitmq_config_file }}'
+    insertafter: 'Network Connectivity'
+    regexp: '^\s*{tcp_listeners,'
+    line: "    {tcp_listeners, [{% for interface in rabbitmq_interface%}{\"{{interface}}\", {{rabbitmq_port}}}{% if loop.index != loop.length %},{% endif %}{% endfor %}]}"
+  notify: restart rabbitmq
+
 - name: Start the rabbitmq service
   service:
    name: '{{ rabbitmq_service_name }}'
@@ -12,7 +20,7 @@
    enabled: yes
   when: manage_services|default(false)
 
-- name: Register rabbitmq firewal ports
+- name: Register rabbitmq firewall ports
   set_fact:
     firewall_ports: >
       {{ firewall_ports + ['{{ rabbitmq_port }}'] }}


### PR DESCRIPTION
The playbook as it is right now allow only one to configure RabbitMQ to
listen on all interface and on port 5672.

In a real life deployment when RabbitMQ might be deployed on a server
with more than one NIC, each network having its own purpose,
making it available to all network is not recommended, hence the
operator should have a way to specify on which interface to listen on.

Port is a parameter but wasn't enforced at the configuration level, just
the firewall level. This commit allows on to be able to set the port
value at the configuration level.
