### PR TITLE
ElasticSearch: Allow one to specify on which address to listen on

### DIFF
--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -8,8 +8,14 @@ elasticsearch_config_yml: '{{ elasticsearch_config_dir }}/elasticsearch.yml'
 elasticsearch_sysconfig: {}
 elasticsearch_sysconfig_path: /etc/sysconfig/elasticsearch
 elasticsearch_cluster_name: elasticsearch
+elasticsearch_port: 9200
+elasticsearch_interface:
+  - 127.0.0.1
+  - ::1
 
 elasticsearch_config:
   cluster.name: '{{ elasticsearch_cluster_name }}'
   http.cors.enabled: true
   http.cors.allow-origin: '/.*/'
+  network.host: '{{ elasticsearch_interface }}'
+  http.port: '{{ elasticsearch_port }}'

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -23,3 +23,8 @@
     state: running
     enabled: true
   when: manage_services|default(false)
+
+- name: register elasticsearch firewall ports
+  set_fact:
+    firewall_ports: >
+      {{ firewall_ports + [elasticsearch_port] }}


### PR DESCRIPTION
This commit allows an operator to specify on which address to listen on
and on which port, using respectively `elasticsearch_interface` and
`elasticsearch_port` variable.
