### PR TITLE
Added java dependency to elasticsearch

### DIFF
--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -19,3 +19,5 @@ elasticsearch_config:
   http.cors.allow-origin: '/.*/'
   network.host: '{{ elasticsearch_interface }}'
   http.port: '{{ elasticsearch_port }}'
+
+java_package_name: java

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: install java package
+  package:
+    name: '{{ java_package_name }}'
+    state: present
+  when: manage_packages|default(false)
+
 - name: install elasticsearch package
   package:
     name: '{{ elasticsearch_package_name }}'


### PR DESCRIPTION
The elasticsearch package from the elastic.co repo does not include the java package as a depency, so we need to installed "manually"
