### PR TITLE
Listen on external port

### DIFF
--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -2,8 +2,7 @@
 rabbitmq_port: 5672
 rabbitmq_server: localhost
 rabbitmq_interface:
-  - 127.0.0.1
-  - ::1
+  - "::"
 
 rabbitmq_service_name: rabbitmq-server
 rabbitmq_package_name: rabbitmq-server

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -10,7 +10,7 @@
     dest: '{{ rabbitmq_config_file }}'
     insertafter: 'Network Connectivity'
     regexp: '^\s*{tcp_listeners,'
-    line: "    {tcp_listeners, [{% for interface in rabbitmq_interface%}{\"{{interface}}\", {{rabbitmq_port}}}{% if loop.index != loop.length %},{% endif %}{% endfor %}]}"
+    line: "    {tcp_listeners, [{% set comma = joiner(\",\") %}{% for ifc in rabbitmq_interface %}{{ comma() }}{\"{{ ifc }}\", {{ rabbitmq_port }}}{% endfor %}]}"
   notify: restart rabbitmq
 
 - name: Start the rabbitmq service
@@ -29,4 +29,3 @@
   set_fact:
     firewall_ports: >
       {{ firewall_ports + [rabbitmq_port] }}
-


### PR DESCRIPTION
This patch adds default IP adresses to the list of ports RabbitMQ
is listening to, so that the instance can be used together with
TripleO out of the box.
