### PR TITLE
correct syntax error in rabbitmq module

### DIFF
--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -28,5 +28,5 @@
 - name: Register rabbitmq firewall ports
   set_fact:
     firewall_ports: >
-      {{ firewall_ports + ['{{ rabbitmq_port }}'] }}
+      {{ firewall_ports + [rabbitmq_port] }}
 


### PR DESCRIPTION
The firewall port configuration in the rabbitmq role would add the
literal string `{{ rabbitmq_port }}` to the `firewall_ports` variable.
This corrects the syntax in the "Register rabbitmq firewall ports"
task.
