### PR TITLE
Reload firewalld

### DIFF
--- a/roles/firewall/commit/tasks/main.yaml
+++ b/roles/firewall/commit/tasks/main.yaml
@@ -20,3 +20,4 @@
       state: enabled
   with_items: '{{ firewall_ports }}'
   when: firewall_manage_rules and firewall_use_firewalld
+  notify: reload firewalld

--- a/roles/firewall/handlers/main.yml
+++ b/roles/firewall/handlers/main.yml
@@ -2,3 +2,7 @@
 - name: persist iptables
   command: >
     service iptables save
+
+- name: reload firewalld
+  command: >
+    firewall-cmd --reload


### PR DESCRIPTION
Adds handler to reload firewalld after all rules are applied.
Without this ports are not actually opened after playbook finish.
