### PR TITLE
allow empty fluentd ca key passphrase

### DIFF
--- a/roles/fluentd/server/templates/listen_ssl.conf
+++ b/roles/fluentd/server/templates/listen_ssl.conf
@@ -5,7 +5,7 @@
 
   ca_cert_path {{ fluentd_ca_cert_path }}
   ca_private_key_path {{ fluentd_private_key_path }}
-  ca_private_key_passphrase {{ fluentd_private_key_passphrase }}
+  ca_private_key_passphrase {{ fluentd_private_key_passphrase|default("") }}
 
   shared_key {{ fluentd_shared_key }}
 


### PR DESCRIPTION
make fluentd_private_key_passphrase optional, since keys may not have
passwords.
