### PR TITLE
develop a framework for multi-host installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,39 @@
 # opstools-ansible
 Ansible playbooks for deploying OpsTools
 
+## Configuration
+
+Create an ansible inventory file in the `inventory/` directory that
+defines your hosts and maps them to host groups declared in
+`inventory/structure`.  For example:
+
+    server1 ansible_host=192.0.2.7 ansible_user=centos ansible_become=true
+    server2 ansible_host=192.0.2.15 ansible_user=centos ansible_become=true
+
+    [am_hosts]
+    server1
+
+    [logging_hosts]
+    server2
+
+Put any necessary configuration into a ansible variables files.  For
+example, I have a file called `config.yml` that contains:
+
+    fluentd_use_ssl: true
+    fluentd_shared_key: secret
+    fluentd_ca_cert: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+    fluentd_private_key:
+      -----BEGIN RSA PRIVATE KEY-----
+      ...
+      -----END RSA PRIVATE KEY-----
+
+Then run the playbook like this:
+
+    ansible-playbook playbook.yml -i inventory -e @config.yml
+
 ## Running tests
 
 You can run simple YAML validation tests by running:

--- a/inventory/structure
+++ b/inventory/structure
@@ -1,0 +1,57 @@
+# ------------------------------------------
+# High-level hostgroups
+#
+# Add hosts to these groups (ideally by creating an additional inventory
+# file in the inventory directory, rather than editing this file) to
+# set up typical groups of services.
+
+[am_hosts]
+# Availability monitoring
+
+[pm_hosts]
+# Performance monitoring
+
+[logging_hosts]
+# Logging
+
+# ------------------------------------------
+# Low-level hostgroups
+#
+# Add hosts to these groups for more granular control of service placement.
+# If you are using these low-level hostgroups, you should not add hosts to
+# any of the high-level hostgroups.
+
+[rabbit_hosts]
+[redis_hosts]
+[sensu_hosts]
+[uchiwa_hosts]
+[fluent_hosts]
+[elastic_hosts]
+[kibana_hosts]
+[grafana_hosts]
+
+# ------------------------------------------
+
+[rabbit_hosts:children]
+am_hosts
+
+[redis_hosts:children]
+am_hosts
+
+[sensu_hosts:children]
+am_hosts
+
+[uchiwa_hosts:children]
+am_hosts
+
+[fluent_hosts:children]
+logging_hosts
+
+[elastic_hosts:children]
+logging_hosts
+
+[kibana_hosts:children]
+logging_hosts
+
+[grafana_hosts:children]
+pm_hosts

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,25 @@
+- hosts: fluent_hosts
+  roles:
+    - fluentd/server
+    - fluentd/syslog
+    - fluentd/elasticsearch
+
+- hosts: elastic_hosts
+  roles:
+    - elasticsearch
+
+- hosts: kibana_hosts
+  roles:
+    - kibana
+
+- hosts: redis_hosts
+  roles:
+    - redis
+
+- hosts: rabbit_hosts
+  roles:
+    - rabbitmq
+
+- hosts: all
+  roles:
+    - firewall/commit

--- a/roles/kibana/server/defaults/main.yml
+++ b/roles/kibana/server/defaults/main.yml
@@ -7,7 +7,7 @@ kibana_config_file: '{{ kibana_config_dir }}/kibana.yml'
 kibana_config_mode: 0644
 kibana_owner: kibana
 kibana_group: kibana
-kibana_elasticsearch_host: localhost
+kibana_elasticsearch_host: "{{ hostvars[groups.elastic_hosts.0].ansible_default_ipv4.address}}"
 kibana_elasticsearch_port: 9200
 
 # "0.0.0.0" to allow public access

--- a/roles/profiles/allinone/meta/main.yml
+++ b/roles/profiles/allinone/meta/main.yml
@@ -1,5 +1,0 @@
----
-dependencies:
-  - profiles/logging
-  - profiles/availability-monitoring
-  - profiles/performance-monitoring

--- a/roles/profiles/availability-monitoring/meta/main.yml
+++ b/roles/profiles/availability-monitoring/meta/main.yml
@@ -1,4 +1,0 @@
----
-dependencies:
-  - sensu/server
-  - uchiwa

--- a/roles/profiles/logging/meta/main.yml
+++ b/roles/profiles/logging/meta/main.yml
@@ -1,7 +1,0 @@
----
-dependencies:
-  - elasticsearch
-  - kibana
-  - fluentd/server
-  - fluentd/syslog
-  - fluentd/elasticsearch

--- a/roles/profiles/performance-monitoring/meta/main.yml
+++ b/roles/profiles/performance-monitoring/meta/main.yml
@@ -1,4 +1,0 @@
----
-dependencies:
-  - collectd
-  - grafana


### PR DESCRIPTION
this introduces an inventory structure that allows for a very
high-level description of what services should be installed on which
hosts, while still allowing for granular control in those situations
in which it is necessary.

With this change applied, the example configuration described in
`README.md` works as expected.
