### PR TITLE
Make Sensu Redis and RabbitMQ configuration flexible

### DIFF
--- a/roles/sensu/common/defaults/main.yml
+++ b/roles/sensu/common/defaults/main.yml
@@ -9,7 +9,8 @@ sensu_config_path: /etc/sensu/conf.d
 sensu_owner: sensu
 sensu_group: sensu
 
+sensu_rabbitmq_server: 127.0.0.1
+sensu_rabbitmq_port: 5672
 sensu_rabbitmq_user: sensu
 sensu_rabbitmq_password: sensu
 sensu_rabbitmq_vhost: /sensu
-

--- a/roles/sensu/common/templates/rabbitmq.json.j2
+++ b/roles/sensu/common/templates/rabbitmq.json.j2
@@ -1,10 +1,9 @@
 {
    "rabbitmq": {
-     "port": {{ rabbitmq_port }},
-     "host": "{{ rabbitmq_server }}",
+     "port": {{ sensu_rabbitmq_port }},
+     "host": "{{ sensu_rabbitmq_server }}",
      "user": "{{ sensu_rabbitmq_user }}",
      "password": "{{ sensu_rabbitmq_password }}",
      "vhost": "{{ sensu_rabbitmq_vhost }}"
    }
  }
-

--- a/roles/sensu/server/defaults/main.yml
+++ b/roles/sensu/server/defaults/main.yml
@@ -3,7 +3,8 @@ sensu_api_bind: 0.0.0.0
 sensu_api_port: 4567
 sensu_api_server: localhost
 
-sensu_server_interface: localhost
+sensu_redis_host: 127.0.0.1
+sensu_redis_port: 6379
 
 oscheck_default_username: admin
 oscheck_default_password: pass

--- a/roles/sensu/server/meta/main.yml
+++ b/roles/sensu/server/meta/main.yml
@@ -1,5 +1,3 @@
 ---
 dependencies:
-  - rabbitmq/sensu
-  - redis
   - sensu/common

--- a/roles/sensu/server/templates/redis.json.j2
+++ b/roles/sensu/server/templates/redis.json.j2
@@ -1,6 +1,6 @@
  {
    "redis": {
-     "port": {{ redis_listen_port }},
-     "host": "{{ sensu_server_interface }}" 
+     "port": {{ sensu_redis_port }},
+     "host": "{{ sensu_redis_host }}"
    }
 }

--- a/test_sensu.yml
+++ b/test_sensu.yml
@@ -4,5 +4,8 @@
   vars:
       firewall_manage_rules: true
   roles:
+    - redis
+    - rabbitmq/sensu
     - sensu/server
+    - uchiwa
     - firewall/commit


### PR DESCRIPTION
- Sensu role should not be dependent on Redis and RabbitMQ role
  to enable multihost deployment
- We should not use localhost in Sensu configuration due to:
  https://github.com/sensu/sensu-docs/issues/347
