### PR TITLE
make elasticsearch role require firewall role

### DIFF
--- a/roles/elasticsearch/meta/main.yml
+++ b/roles/elasticsearch/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - firewall


### PR DESCRIPTION
without this patch, deployments could fail with:

```
TASK [elasticsearch : register elasticsearch firewall ports] *******************
fatal: [server1]: FAILED! => {"failed": true, "msg": "'firewall_ports' is undefined"}
```
