### PR TITLE
Install RDO repo before Redis and Rabbit

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -19,11 +19,13 @@
 - name: Install Redis
   hosts: redis_hosts
   roles:
+    - rdo
     - redis
 
 - name: Install RabbitMQ
   hosts: rabbit_hosts
   roles:
+    - rdo
     - rabbitmq/server
 
 - name: Install Sensu


### PR DESCRIPTION
We need RDO repo to be able to install RabbitMQ and Redis.
