### PR TITLE
ensure appropriate sensu version is installed

### DIFF
--- a/roles/sensu/common/defaults/main.yml
+++ b/roles/sensu/common/defaults/main.yml
@@ -14,3 +14,5 @@ sensu_rabbitmq_port: 5672
 sensu_rabbitmq_user: sensu
 sensu_rabbitmq_password: sensu
 sensu_rabbitmq_vhost: /sensu
+
+sensu_minimum_version: "1:0.26.0"

--- a/roles/sensu/common/tasks/main.yml
+++ b/roles/sensu/common/tasks/main.yml
@@ -5,6 +5,28 @@
     dest: '{{ yum_repos_d }}/sensu.repo'
   when: manage_repos|default(false)
 
+- name: Ensure repoquery command is available
+  package:
+    name: yum-utils
+    state: present
+  when: manage_packages|default(false)
+
+- name: Check for obsolete sensu package
+  command: >
+    repoquery --installed --whatprovides
+    '{{ sensu_package_name }} <= {{ sensu_minimum_version }}'
+  changed_when: false
+  failed_when: false
+  register: sensu_version
+  when: manage_packages|default(false)
+
+- name: Remove obsolete sensu package
+  package:
+    name: '{{ item }}'
+    state: absent
+  with_items: '{{ sensu_version.stdout_lines }}'
+  when: manage_packages|default(false)
+
 - name: Install sensu
   package:
     name: '{{ sensu_package_name }}'

--- a/roles/sensu/common/templates/rabbitmq.json.j2
+++ b/roles/sensu/common/templates/rabbitmq.json.j2
@@ -1,7 +1,7 @@
 {
    "rabbitmq": {
-     "port": {{ rabbitmq_port }},
-     "host": "{{ rabbitmq_server }}",
+     "port": {{ sensu_rabbitmq_port }},
+     "host": "{{ sensu_rabbitmq_server }}",
      "user": "{{ sensu_rabbitmq_user }}",
      "password": "{{ sensu_rabbitmq_password }}",
      "vhost": "{{ sensu_rabbitmq_vhost }}"

--- a/roles/sensu/server/tasks/main.yml
+++ b/roles/sensu/server/tasks/main.yml
@@ -62,6 +62,20 @@
     - restart rabbitmq
   with_items: "{{ groups.rabbit_hosts }}"
 
+# This is a workaround for https://github.com/sensu/sensu/issues/1478
+- name: Ensure correct ownership on directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: sensu
+    group: sensu
+    recurse: true
+  with_items:
+    - /var/log/sensu
+    - /var/run/sensu
+  notify:
+    - restart sensu
+
 - name: ensure sensu is started and enabled at boot
   service:
     name: '{{ item }}'


### PR DESCRIPTION
there is an older version of sensu available in centos (and
pre-installed on some overcloud images).  Ensure that we replace it
with the package from the sensuapp repository.
