### PR TITLE
configure default redirect for apache

### DIFF
--- a/roles/kibana/proxy/tasks/main.yml
+++ b/roles/kibana/proxy/tasks/main.yml
@@ -12,3 +12,11 @@
     htpasswd -cb {{ kibana_proxy_htpasswd }} {{ kibana_proxy_user }}
     {{ kibana_proxy_pass }}
   notify: restart httpd
+
+- name: Configure default redirect
+  copy:
+    content: |
+      RewriteRule ^/$ {{ kibana_path }} [R=302]
+    dest: '{{ opstools_default_redirect_file }}'
+    force: false
+  notify: restart httpd

--- a/roles/opstoolsvhost/defaults/main.yml
+++ b/roles/opstoolsvhost/defaults/main.yml
@@ -7,3 +7,5 @@ opstools_apache_sslcert: "/etc/pki/tls/certs/localhost.crt"
 opstools_apache_sslkey: "/etc/pki/tls/private/localhost.key"
 opstools_apache_http_port: 80
 opstools_apache_https_port: 443
+opstools_default_redirect_file: >-
+  {{ opstools_apache_config_dir }}/default_redirect.conf

--- a/roles/uchiwa/proxy/tasks/main.yml
+++ b/roles/uchiwa/proxy/tasks/main.yml
@@ -12,3 +12,11 @@
     htpasswd -cb {{ uchiwa_proxy_htpasswd }} {{ uchiwa_proxy_user }}
     {{ uchiwa_proxy_pass }}
   notify: restart httpd
+
+- name: Configure default redirect
+  copy:
+    content: |
+      RewriteRule ^/$ {{ uchiwa_path }} [R=302]
+    dest: '{{ opstools_default_redirect_file }}'
+    force: false
+  notify: restart httpd


### PR DESCRIPTION
This allows both the sensu and kibana roles to configure a default
redirect for access to "/" on the webserver.  When both roles are
installed on the same system, whichever is installed first will win.
