### PR TITLE
Make apache own htpasswd files

### DIFF
--- a/roles/kibana/proxy/tasks/main.yml
+++ b/roles/kibana/proxy/tasks/main.yml
@@ -13,6 +13,13 @@
     {{ kibana_proxy_pass }}
   notify: restart httpd
 
+- name: secure htpasswd file
+  file:
+    path: '{{ kibana_proxy_htpasswd }}'
+    owner: apache
+    group: apache
+    mode: 0640
+
 - name: Configure default redirect
   copy:
     content: |

--- a/roles/uchiwa/proxy/tasks/main.yml
+++ b/roles/uchiwa/proxy/tasks/main.yml
@@ -13,6 +13,13 @@
     {{ uchiwa_proxy_pass }}
   notify: restart httpd
 
+- name: secure uchiwa htpasswd file
+  file:
+    path: '{{ uchiwa_proxy_htpasswd }}'
+    owner: apache
+    group: apache
+    mode: 0640
+
 - name: Configure default redirect
   copy:
     content: |


### PR DESCRIPTION
htpasswd files are being created by root and are readable by
others. This patch makes sure, they are owned by apache user
and only apache user and group are allowed to read the file.
