### PR TITLE
allow playbooks to target RHEL hosts

### DIFF
--- a/roles/repos/rdo/tasks/main.yml
+++ b/roles/repos/rdo/tasks/main.yml
@@ -3,4 +3,4 @@
   package:
     name: centos-release-openstack-{{rdo_release}}
     state: present
-  when: manage_repos|default(false)
+  when: manage_repos|default(false) and ansible_distribution == 'CentOS'


### PR DESCRIPTION
we attempt to install centos-release-openstack-\* releas packages in
roles/repos/rdo, which will fail on RHEL hosts.  This change makes
that task conditional on ansible_distribution == 'CentOS'.
