### PR TITLE
add chrony role to provide ntp sync

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -3,6 +3,7 @@
   roles:
     - prereqs
     - repos
+    - chrony
 
 - name: Install ElasticSearch
   hosts: elastic_hosts

--- a/roles/chrony/defaults/main.yml
+++ b/roles/chrony/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+chrony_package_name: chrony
+chrony_service_name: chronyd
+chrony_config_file: /etc/chrony.conf
+chrony_driftfile: /var/lib/chrony/drift
+chrony_logdir: /var/log/chrony
+
+chrony_pools:
+  - pool.ntp.org iburst
+
+chrony_default_config:
+  - 'makestep 1.0 3'
+  - 'rtcsync'

--- a/roles/chrony/handlers/main.yml
+++ b/roles/chrony/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart chronyd
+  service:
+    name: '{{ chrony_service_name }}'
+    state: restarted
+  when: manage_services|default(false)

--- a/roles/chrony/tasks/main.yml
+++ b/roles/chrony/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Install chrony package
+  package:
+    name: '{{ chrony_package_name }}'
+    state: present
+  when: manage_packages|default(false)
+
+- name: Generate chrony configuration
+  template:
+    src: chrony.conf.j2
+    dest: '{{ chrony_config_file }}'
+  notify: Restart chronyd
+
+- name: Activate chrony service
+  service:
+    name: '{{ chrony_service_name }}'
+    state: running
+    enabled: true
+  when: manage_services|default(false)

--- a/roles/chrony/templates/chrony.conf.j2
+++ b/roles/chrony/templates/chrony.conf.j2
@@ -1,0 +1,18 @@
+driftfile {{ chrony_driftfile }}
+logdir {{ chrony_logdir }}
+
+{% for pool in chrony_pools|default([]) %}
+pool {{ pool }}
+{% endfor %}
+
+{% for server in chrony_servers|default([]) %}
+server {{ server }}
+{% endfor %}
+
+{% for cfg in chrony_default_config|default([]) %}
+{{ cfg }}
+{% endfor %}
+
+{% for cfg in chrony_extra_config|default([]) %}
+{{ cfg }}
+{% endfor %}


### PR DESCRIPTION
it is critical that the opstool server has the correct time (and that
it is synchronized with any client systems).  This change adds a
"chrony" role that will install and configure the "chrony" ntp client.
