### PR TITLE
add uchiwa user to sensu group

### DIFF
--- a/roles/uchiwa/defaults/main.yml
+++ b/roles/uchiwa/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 uchiwa_package_name: uchiwa
 uchiwa_service_name: uchiwa
+uchiwa_extra_groups:
+  - sensu
 
 uchiwa_bind: 127.0.0.1
 uchiwa_server_address: localhost

--- a/roles/uchiwa/tasks/main.yml
+++ b/roles/uchiwa/tasks/main.yml
@@ -12,6 +12,11 @@
   notify:
     - restart uchiwa
 
+- name: Add uchiwa user to additional groups
+  user:
+    name: uchiwa
+    groups: '{{ ",".join(uchiwa_extra_groups) }}'
+
 - name: ensure uchiwa is started and enabled at boot
   service:
     name: '{{ uchiwa_service_name }}'


### PR DESCRIPTION
ensure that the `uchiwa` user is a member of the `sensu` group.  This
is done upon new installation of the `uchiwa` package, but in the case
of an upgrade, if the `uchiwa` user already exists it will not be
modified.
