### PR TITLE
lots of documentation updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+DEFAULTS = $(shell find roles -path '*/defaults/main.yml')
+READMES = $(shell find roles -name README.md)
+PANDOC_EXTENSIONS = yaml_metadata_block+auto_identifiers+implicit_header_references
+
+MARKDOWN = README.md
+HTML = $(MARKDOWN:.md=.html)
+
+all: $(MARKDOWN) $(HTML)
+
+README.md: $(DEFAULTS) $(READMES) docs/header.md docs/footer.md
+	(cat docs/header.md && \
+	python tools/extract-role-docs.py && \
+	cat docs/footer.md) > $@ || rm -f $@
+
+README.html: README.md docs/metadata.yml
+	pandoc -f markdown+$(PANDOC_EXTENSIONS) \
+	docs/metadata.yml README.md -o $@ \
+	--standalone --toc --toc-depth 2
+
+clean:
+	rm -f $(MARKDOWN) $(HTML)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,36 @@
-# opstools-ansible
-Ansible playbooks for deploying OpsTools
+<!-- README.md is generated automatically from files and scripts in
+the docs/ directory.  If you are editing README.md directly your
+changes will be lost. -->
 
-## Configuration
+# Overview
 
-Create an ansible inventory file in the `inventory/` directory that
-defines your hosts and maps them to host groups declared in
-`inventory/structure`.  For example:
+The [opstools-ansible][] project is a collection of Ansible roles and
+playbooks that will configure an environment that provides centralized
+logging and analysis, availability monitoring, and performance
+monitoring.
+
+[tripleo]:https://wiki.openstack.org/wiki/TripleO
+[opstools-ansible]: https://github.com/larsks/opstools-ansible/
+
+# Using opstools-ansible
+
+## Before you begin
+
+Before using the opstools-ansible playbook, you will need to deploy
+one or more servers on which you will install the opstools services.
+These servers will need to be running either CentOS 7 or RHEL 7 (or a
+compatible distribution).
+
+These playbooks will install packages from a number of third-party
+repositories.  The opstools-ansible developers are unable to address
+problems with the third party packaging (other than via working around
+problems in our playbooks).
+
+## Creating an inventory file
+
+Create an Ansible inventory file `inventory/hosts` that defines your
+hosts and maps them to host groups declared in `inventory/structure`.
+For example:
 
     server1 ansible_host=192.0.2.7 ansible_user=centos ansible_become=true
     server2 ansible_host=192.0.2.15 ansible_user=centos ansible_become=true
@@ -16,8 +41,25 @@ defines your hosts and maps them to host groups declared in
     [logging_hosts]
     server2
 
-Put any necessary configuration into a ansible variables files.  For
-example, I have a file called `config.yml` that contains:
+There are two high-level groups that can be used to control service
+placement:
+
+- `am_hosts`: The playbooks will install availability monitoring
+  software (Sensu, Uchiwa, and support services) on these hosts.
+
+- `logging_hosts`: The playbooks will install the centralized logging
+  stack (Elasticsearch, Kibana, Fluentd) on these hosts.
+
+While there are more groups defined in the
+`inventory/structure` file, use of those for more granular service
+placement is neither tested nor supported at this time.
+
+## Create a configuration file
+
+Put any necessary configuration into an Ansible variables file (which
+is just a YAML document).  For example, if you wanted to enable
+logging via SSL, you would need a configuration file that looked like
+this:
 
     fluentd_use_ssl: true
     fluentd_shared_key: secret
@@ -30,19 +72,890 @@ example, I have a file called `config.yml` that contains:
       ...
       -----END RSA PRIVATE KEY-----
 
-Then run the playbook like this:
+You don't need a configuration file if you wish to use default
+options.
+
+## Run the playbook
+
+Once you have your inventory and configuration in place, you can run
+the playbook like this:
 
     ansible-playbook playbook.yml -i inventory -e @config.yml
 
-## Running tests
+# Roles
 
-You can run simple YAML validation tests by running:
+The following documentation is automatically extracted from the
+`roles` directory in this distribution.
 
-    tox
+<!-- automatically generated content will be placed here -->
+## Fluentd
 
-## License
+[Fluentd][] is a log collection tool.  It can collect logs from a
+variety of sources, filter them, and send them to a variety of
+destinations, including remote Fluentd instances.
 
-Copyright 2016 Red Hat, Inc.
+We use Fluentd to receive logs from remote Fluentd clients and deliver
+them to [Elasticsearch][].
+
+[fluentd]: http://www.fluentd.org/
+[elasticsearch]: https://www.elastic.co/products/elasticsearch
+
+### Configuration
+
+- `fluentd_package_name` (default: `"fluentd"`)
+
+    Fluentd package name.
+
+- `fluentd_service_name` (default: `"fluentd"`)
+
+    Fluentd service name.
+
+- `fluentd_config_dir` (default: `"/etc/fluentd"`)
+
+    Path to the Fluentd configuration directory.
+
+- `fluentd_config_file` (default: `"{{ fluentd_config_dir }}/fluent.conf"`)
+
+    Path to the main Fluentd configuration file.
+
+- `fluentd_config_parts_dir` (default: `"{{ fluentd_config_dir }}/config.d"`)
+
+    Path to the directory containing Fluentd configuration snippets.
+
+- `fluentd_owner` (default: `"fluentd"`)
+
+    User that will own Fluentd config files.
+
+- `fluentd_group` (default: `"fluentd"`)
+
+    Group that will own Fluentd config files.
+
+- `fluentd_config_mode` (default: `420`)
+
+    File mode for Fluentd configuration files.
+
+- `fluentd_plugins` (default: `["rubygem-fluent-plugin-secure-forward", "rubygem-fluent-plugin-add"]`)
+
+    A list of Fluentd plugins to install along with Fluentd.
+
+- `fluentd_listen` (default: `false`)
+
+    Set to true if Fluentd should listen for connections from remote
+    Fluentd instances.
+
+- `fluentd_use_ssl` (default: `false`)
+
+    Set to true if Fluentd should use SSL.
+
+- `fluentd_shared_key` (default: `null`)
+
+    Shared secret key for SSL connections.
+
+- `fluentd_ca_cert_path` (default: `"{{ fluentd_config_dir }}/ca_cert.pem"`)
+
+    Where to find the Fluentd server certificate authority certificate.
+
+- `fluentd_ca_cert` (default: `null`)
+
+    Content of an x509 certificate that will be used to identify the
+    server to clients.
+
+- `fluentd_private_key` (default: `null`)
+
+    The key corresponding to the certificate in `fluentd_ca_cert`.
+
+
+## Fluentd/Server
+
+This role configures a Fluentd listener that will listen for remote
+connections from other Fluentd clients.
+
+### Configuration
+
+- `fluentd_server_plugins` (default: `["rubygem-fluent-plugin-elasticsearch"]`)
+
+    A list of plugins that will be installed on the fluentd server.
+
+- `fluentd_private_key_path` (default: `"{{ fluentd_config_dir }}/ca_key.pem"`)
+
+    Path to the SSL certificate private key.
+
+- `fluentd_server_extraconfig` (default: `{}`)
+
+    Additional fluentd configuration.
+
+
+## Fluentd/Elasticsearch
+
+This role contains contains configuration to send logs from Fluentd to
+an Elasticsearch instance.
+
+### Configuration
+
+- `fluentd_elasticsearch_host` (default: `"localhost"`)
+
+    Address of the Elasticsearch host.
+
+- `fluentd_elasticsearch_port` (default: `9200`)
+
+    Port on which Elasticsearch is accepting connections.
+
+- `fluentd_elasticsearch_index` (default: `"fluentd"`)
+
+    Elasticsearch index name.
+
+- `fluentd_elasticsearch_type` (default: `"fluentd"`)
+
+    Elasticsearch index type.
+
+- `fluentd_elasticsearch_extraconfig` (default: `{}`)
+
+    Additional Fluentd configuration to apply to the Elasticsearch
+    output snippet.
+
+
+## Fluentd/Syslog
+
+This roles installs the necessary configuration to send logs from the
+local syslog server to a Fluentd instance.
+
+### Configuration
+
+- `fluentd_syslog_bind_address` (default: `"127.0.0.1"`)
+
+    Address on which to listen for syslog messages.
+
+- `fluentd_syslog_port` (default: `5140`)
+
+    Port on which to listen for syslog messages.
+
+- `fluentd_syslog_tag` (default: `"system.messages"`)
+
+    Fluentd tag to apply to syslog messages.
+
+
+## Firewall
+
+This role manages the system firewall using either `iptables` or
+`firewalld`.
+
+### Configuration
+
+- `firewall_ports` (default: `[]`)
+
+    A list of ports that should be exposed in the system firewall.
+    Roles register ports by appending them to this list using the
+    `set_fact` module.
+
+- `firewall_manage_rules` (default: `true`)
+
+    Set this to False if you do not want the playbooks to make changes
+    to the system firewall.
+
+
+## Firewall/Commit
+
+This role instantiates the firewall rules that were registered by
+other roles during the playbook run.
+
+## Collectd
+
+
+### Configuration
+
+- `collectd_service_name` (default: `"collectd"`)
+
+
+
+
+## Grafana
+
+
+### Configuration
+
+- `grafana_package_name` (default: `"grafana"`)
+
+
+
+
+## Sensu/Server
+
+This role is responsible for installing and configuring the Sensu
+server.
+
+### Configuration
+
+- `sensu_api_bind` (default: `"0.0.0.0"`)
+
+    Address on which Sensu should listen for connections.
+
+- `sensu_api_port` (default: `4567`)
+
+    Port on which Sensu should listen.
+
+- `sensu_api_server` (default: `"localhost"`)
+
+    Address to which clients should connect to contact the Sensu API.
+
+- `sensu_redis_server` (default: `"127.0.0.1"`)
+
+    Address of the Redis server to which Sensu should connect.
+
+- `sensu_redis_port` (default: `"{{ redis_listen_port }}"`)
+
+    Port on which the Redis server listens.
+
+- `sensu_redis_password` (default: `"{{ redis_password }}"`)
+
+    Password for authenticating to Redis.
+
+- `sensu_enabled_oschecks` (default: `["check-ceilometer_api", "check-ceph_df", "check-ceph_health", "check-cinder_api", "check-cinder_volume", "check-glance_api", "check-keystone_api", "check-neutron_api", "check-nova_api", "check-nova_instance"]`)
+
+    A list of enabled Sensu checks.
+
+- `oscheck_default_username` (default: `"admin"`)
+
+    Username for openstack checks.
+
+- `oscheck_default_password` (default: `"pass"`)
+
+    Password for openstack checks.
+
+- `oscheck_default_project_name` (default: `"admin"`)
+
+    Project name (aka tenant) for openstack checks.
+
+- `oscheck_default_auth_url` (default: `"http://controller:5000/v2.0"`)
+
+    Authentication URL (Keystone server) for openstack checks.
+
+- `oscheck_subscribers_cinder_volume` (default: `"overcloud-cinder-volume"`)
+
+    Region name for openstack checks.
+
+
+## Sensu/Common
+
+[Sensu][] is a distributed monitoring solution. This role installs the
+Sensu package and performs some basic configuration tasks.
+
+[sensu]: http://sensuapp.org/
+
+### Configuration
+
+- `sensu_package_name` (default: `"sensu"`)
+
+    Sensu package name.
+
+- `sensu_server_service_name` (default: `"sensu-server"`)
+
+    Sensu server service name.
+
+- `sensu_api_service_name` (default: `"sensu-api"`)
+
+    Sensu API service name.
+
+- `sensu_client_service_name` (default: `"sensu-client"`)
+
+    Sensu client service name.
+
+- `sensu_config_path` (default: `"/etc/sensu/conf.d"`)
+
+    Path to Sensu configuration directory.
+
+- `sensu_owner` (default: `"sensu"`)
+
+    Owner of Sensu configuration files.
+
+- `sensu_group` (default: `"sensu"`)
+
+    Group of Sensu configuration files.
+
+- `sensu_rabbitmq_server` (default: `"localhost"`)
+
+    Address of RabbitMQ server to which Sensu should connect.
+
+- `sensu_rabbitmq_port` (default: `5672`)
+
+    Port of the RabbitMQ server.
+
+- `sensu_rabbitmq_user` (default: `"sensu"`)
+
+    Authenticate to RabbitMQ server as this user.
+
+- `sensu_rabbitmq_password` (default: `"sensu"`)
+
+    Authenticate to RabbitMQ server with this password.
+
+- `sensu_rabbitmq_vhost` (default: `"/sensu"`)
+
+    RabbitMQ vhost for use by Sensu.
+
+
+## Opstoolsvhost
+
+This role is responsible for configuring the Apache virtual host that
+will host Ops Tools services.
+
+### Configuration
+
+- `opstools_apache_config_file` (default: `"{{ httpd_config_parts_dir }}/opstools.conf"`)
+
+    Path to the Apache configuration file for the Ops Tools virtual host.
+
+- `opstools_apache_config_dir` (default: `"{{ opstools_apache_config_file }}.d"`)
+
+    Path to the directory from which we will read additional
+    configuration snipps inside the OpsTools virtual host context.
+
+- `opstools_apache_sslprotocol` (default: `"all -SSLv2"`)
+
+    Apache SSL protocol settings.
+
+- `opstools_apache_sslciphersuite` (default: `"HIGH:MEDIUM:!aNULL:!MD5:!SEED:!IDEA"`)
+
+    Apache SSL cipher suite settings.
+
+- `opstools_apache_sslcert` (default: `"/etc/pki/tls/certs/localhost.crt"`)
+
+    Path to server SSL certificate.
+
+- `opstools_apache_sslkey` (default: `"/etc/pki/tls/private/localhost.key"`)
+
+    Path to SSL private key.
+
+- `opstools_apache_http_port` (default: `80`)
+
+    Port on which to listen for HTTP connections.
+
+- `opstools_apache_https_port` (default: `443`)
+
+    Port on which to listen for HTTPS connections.
+
+- `opstools_default_redirect_file` (default: `"\n{{ opstools_apache_config_dir }}/default_redirect.conf"`)
+
+    Path to configuration file that sets the default redirect for access
+    to the root URL (`/`).
+
+
+## Elasticsearch
+
+[Elasticsearch][] is a search and analytics engine used by Ops Tools
+to collect, index, search, and analyze logs.
+
+[elasticsearch]: https://www.elastic.co/products/elasticsearch
+
+### Configuration
+
+- `elasticsearch_package_name` (default: `"elasticsearch"`)
+
+    Name of the Elasticsearch pacakge
+
+- `elasticsearch_service_name` (default: `"elasticsearch"`)
+
+    Name of the Elasticsearch service.
+
+- `elasticsearch_config_dir` (default: `"/etc/elasticsearch"`)
+
+    Path to the Elasticsearch configuration directory.
+
+- `elasticsearch_config_yml` (default: `"{{ elasticsearch_config_dir }}/elasticsearch.yml"`)
+
+    Path to the main Elasticsearch configuration file.
+
+- `elasticsearch_sysconfig` (default: `{}`)
+
+    Values that will be set in /etc/sysconfig/elasticsearch.
+
+- `elasticsearch_sysconfig_path` (default: `"/etc/sysconfig/elasticsearch"`)
+
+    Path to Elasticsearch sysconfig file.
+
+- `elasticsearch_cluster_name` (default: `"elasticsearch"`)
+
+    Elasticsearch cluster name.
+
+- `elasticsearch_port` (default: `9200`)
+
+    Port on which Elasticsearch should listen.
+
+- `elasticsearch_interface` (default: `["127.0.0.1", "::1"]`)
+
+    Addresses on which Elasticsearch should listten.
+
+- `elasticsearch_config` (default: `{"cluster.name": "{{ elasticsearch_cluster_name }}", "network.host": "{{ elasticsearch_interface }}", "http.cors.enabled": true, "http.port": "{{ elasticsearch_port }}", "http.cors.allow-origin": "/.*/"}`)
+
+    Configuration data for Elasticsearch.  The contents of this variable
+    will be rendered as YAML in the file referenced by
+    `elasticsearch_config_yml`.
+
+- `elasticsearch_extraconfig` (default: `{}`)
+
+    Additional configuration data for Elasticsearch.  Use this if you
+    want to add options to `elasticsearch.yml` without replacing the
+    defaults in `elasticsearch_config`.
+
+- `java_package_name` (default: `"java"`)
+
+    Name of the package that provides a Java runtime environment.
+
+
+## Httpd
+
+This role installs the Apache web server and associated modules.
+
+### Configuration
+
+- `httpd_package_name` (default: `"httpd"`)
+
+    Apache package name.
+
+- `httpd_service_name` (default: `"httpd"`)
+
+    Apache service name.
+
+- `httpd_config_dir` (default: `"/etc/httpd"`)
+
+    Path to Apache top-level configuration directory.
+
+- `httpd_config_parts_dir` (default: `"{{ httpd_config_dir }}/conf.d"`)
+
+    Path to directory containing Apache configuration snippets.
+
+- `httpd_owner` (default: `"root"`)
+
+    Owner of Apache configuration files.
+
+- `httpd_group` (default: `"root"`)
+
+    Group of Apache configuration files.
+
+- `httpd_config_mode` (default: `420`)
+
+    Mode of Apache configuration files.
+
+- `httpd_modules` (default: `["mod_ssl"]`)
+
+    Modules that will be installed along with Apache.
+
+
+## Kibana
+
+[Kibana][] is a web interface for querying an [Elasticsearch][] data
+store.
+
+[kibana]: https://www.elastic.co/products/kibana
+[elasticsearch]: https://www.elastic.co/products/elasticsearch
+
+### Configuration
+
+- `kibana_path` (default: `"/kibana"`)
+
+    This is the URL path at which clients can access Kibana.
+
+- `kibana_package_name` (default: `"kibana"`)
+
+    The Kibana package name.
+
+- `kibana_service_name` (default: `"kibana"`)
+
+    The Kibana service name.
+
+- `kibana_config_dir` (default: `"/opt/kibana/config"`)
+
+    Path to the Kibana configuration directory.
+
+- `kibana_config_file` (default: `"{{ kibana_config_dir }}/kibana.yml"`)
+
+    Path to the Kibana configuration file.
+
+- `kibana_config_mode` (default: `420`)
+
+    Mode for the Kibana configuration file.
+
+- `kibana_owner` (default: `"kibana"`)
+
+    Owner for the Kibana configuration file.
+
+- `kibana_group` (default: `"kibana"`)
+
+    Group for the Kibana configuration file.
+
+- `kibana_server_bind` (default: `"localhost"`)
+
+    This is address to which Kibana should bind.
+    Use "0.0.0.0" to listen on all interfaces; use "localhost" to allow
+    access from the local system only.
+
+- `kibana_server_address` (default: `"{{ kibana_server_bind }}"`)
+
+    This is the address to which clients should connect to access Kibana
+    (we can't always use kibana_server_bind for that because 0.0.0.0 is
+    not an address to which we can connect).
+
+- `kibana_server_port` (default: `5601`)
+
+    The port on which Kibana should listen.
+
+- `kibana_elasticsearch_host` (default: `"localhost"`)
+
+    Address of the Elasticsearch host.
+
+- `kibana_elasticsearch_port` (default: `9200`)
+
+    Port on which Elasticsearch is listening.
+
+- `kibana_server_elasticsearch_url` (default: `"\nhttp://{{ kibana_elasticsearch_host }}:{{ kibana_elasticsearch_port }}"`)
+
+    URL for Kibana to contact Elasticsearch.
+
+
+## Kibana/Proxy
+
+This role configures the Apache proxy for Kibana.
+
+### Configuration
+
+- `kibana_proxy_dest` (default: `"http://{{ kibana_server_bind }}:{{ kibana_server_port }}"`)
+
+    The URL for the Kibana service.
+
+- `kibana_proxy_htpasswd` (default: `"/etc/httpd/conf/htpasswd-kibana"`)
+
+    Path to the htpasswd file for Kibana.
+
+- `kibana_proxy_user` (default: `"operator"`)
+
+    Initial username for Kibana access to configure in the htpasswd file.
+
+- `kibana_proxy_pass` (default: `"changeme"`)
+
+    Initial password for Kibana access to configure in the htpasswd file.
+
+- `kibana_httpd_conf` (default: `"{{ opstools_apache_config_dir }}/kibana.conf"`)
+
+    Path to the Apache configuration file for Kibana.
+
+
+## Kibana/Server
+
+This role installs the Kibana web application.  Configuration is taken
+from the main `kibana` role.
+
+## Prereqs
+
+This role installs packages and configuration that are required for
+the successful operation of the opstools-ansible playbooks.
+
+## Prereqs/Libselinuxpython
+
+This role installs the libselinux-python package (required by Ansible).
+
+### Configuration
+
+- `libselinux_python_package_name` (default: `"libselinux-python"`)
+
+    libselinux-python package name
+
+
+## Prereqs/Libsemanagepython
+
+This role installs the libsemanage-python package (required by
+Ansible).
+
+### Configuration
+
+- `libsemanage_python_package_name` (default: `"libsemanage-python"`)
+
+    libsemanage-python package name
+
+
+## Rabbitmq
+
+[RabbitMQ][] is a reliable messaging service.  It is used by [Sensu][]
+agents to communicate with the Sensu server.
+
+[rabbitmq]: https://www.rabbitmq.com/
+[sensu]: https://sensuapp.org/
+
+### Configuration
+
+- `rabbitmq_port` (default: `5672`)
+
+    Port on which RabbitMQ should listen.
+
+- `rabbitmq_server` (default: `"localhost"`)
+
+    Address to which clients should connect to the RabbitMQ service.
+
+- `rabbitmq_interface` (default: `["::"]`)
+
+    Addresses on which RabbitMQ should listen for connections.
+
+- `rabbitmq_package_name` (default: `"rabbitmq-server"`)
+
+    RabbitMQ package name.
+
+- `rabbitmq_service_name` (default: `"rabbitmq-server"`)
+
+    RabbitMQ service name.
+
+- `rabbitmq_default_user` (default: `"guest"`)
+
+    Default RabbitMQ user.
+
+- `rabbitmq_config_file` (default: `"/etc/rabbitmq/rabbitmq.config"`)
+
+    Path to RabbitMQ configuration file.
+
+- `rabbitmq_config_owner` (default: `"rabbitmq"`)
+
+    Owner of RabbitMQ configuration files.
+
+- `rabbitmq_config_group` (default: `"rabbitmq"`)
+
+    Group of RabbitMQ configuration files.
+
+- `rabbitmq_config_mode` (default: `"0644"`)
+
+    Mode of RabbitMQ configuration files.
+
+
+## Rabbitmq/Server
+
+This role is responsible for installing and starting the RabbitMQ
+messaging service.
+
+## Redis
+
+[Redis][] is an in-memory key/value store.  [Sensu][] uses Redis as a
+data-store for storing monitoring data (e.g. a client registry,
+current check results, current monitoring events, etc).
+
+[redis]: http://redis.io/
+[sensu]: http://sensuapp.org/
+
+### Configuration
+
+- `redis_listen_port` (default: `6379`)
+
+    Port on which Redis should listen.
+
+- `redis_password` (default: `"kJadrW$s&5."`)
+
+    Password for accessing the Redis service.
+
+
+## Redis/Server
+
+This role is responsible for installing and configuring the Redis
+service.
+
+### Configuration
+
+- `redis_config_file` (default: `"/etc/redis.conf"`)
+
+    Path to the Redis configuration file.
+
+- `redis_interface` (default: `["127.0.0.1"]`)
+
+    Addresses on which Redis should listen for connections.
+
+- `redis_package_name` (default: `"redis"`)
+
+    Redis package name.
+
+- `redis_service_name` (default: `"redis"`)
+
+    Redis service name.
+
+- `redis_owner` (default: `"redis"`)
+
+    Owner of Redis configuration files.
+
+
+## Repos
+
+This role is a collection of roles for configuring additional package
+repositories.
+
+## Repos/Opstools
+
+This role enables the CentOS OpsTools SIG package repository.
+
+### Configuration
+
+- `opstools_repo_config` (default: `"https://raw.githubusercontent.com/centos-opstools/centos-release-opstools/master/CentOS-OpsTools.repo"`)
+
+    URL to the CentOS OpsTools SIG repository configuration file.
+    yamllint disable-line rule:line-length
+
+
+## Repos/Rdo
+
+This role configures access to the RDO package repository.  This role
+is only used on CentOS hosts; it will not configure RDO repositories
+on RHEL systems.
+
+### Configuration
+
+- `rdo_release` (default: `"mitaka"`)
+
+    Specify which RDO release to use.
+
+
+## Rsyslog
+
+This is a utility role for use by other roles that wish to install
+rsyslog configuration snippets.  It provides a handler that can be
+used to install rsyslogd.  This role will not install or enable
+the rsyslog service.
+
+### Configuration
+
+- `rsyslog_config_dir` (default: `"/etc/rsyslog.d"`)
+
+    Path to the directory containing rsyslog configuration snippets.
+
+
+## Uchiwa
+
+[Uchiwa][] is a web interface to [Sensu][].  This role installs and
+configures the Uchiwa service.
+
+[sensu]: http://sensuapp.org/
+[uchiwa]: https://uchiwa.io/
+
+### Configuration
+
+- `uchiwa_package_name` (default: `"uchiwa"`)
+
+    Uchiwa package name.
+
+- `uchiwa_service_name` (default: `"uchiwa"`)
+
+    Uchiwa service name.
+
+- `uchiwa_bind` (default: `"127.0.0.1"`)
+
+    Address on which Uchiwa should listen for connections.
+
+- `uchiwa_server_address` (default: `"localhost"`)
+
+    Address to which clients should connect to Uchiwa.
+
+- `uchiwa_port` (default: `3000`)
+
+    Port on which Uchiwa should listen.
+
+- `uchiwa_refresh` (default: `5`)
+
+    How often Uchiwa should refresh results.
+
+- `uchiwa_file_path` (default: `"/etc/sensu/uchiwa.json"`)
+
+    Path to Uchiwa configuration file.
+
+- `sensu_datacenters` (default: `[{"host": "{{ sensu_api_server }}", "name": "{{ uchiwa_sensu_api_server_name }}", "port": "{{ sensu_api_port }}"}]`)
+
+    List of Sensu datacenters to which Uchiwa should connect.
+
+
+## Uchiwa/Proxy
+
+This role configures the Apache proxy for Uchiwa.
+
+### Configuration
+
+- `uchiwa_proxy_dest` (default: `"http://{{ uchiwa_bind }}:{{ uchiwa_port }}"`)
+
+    URL for backend Uchiwa service.
+
+- `uchiwa_proxy_htpasswd` (default: `"/etc/httpd/conf/htpasswd-uchiwa"`)
+
+    Path to htpasswd file for controlling access to Uchiwa.
+
+- `uchiwa_proxy_user` (default: `"operator"`)
+
+    User to create in htpasswd file.
+
+- `uchiwa_proxy_pass` (default: `"changeme"`)
+
+    Password for user in htpasswd file.
+
+- `uchiwa_httpd_conf` (default: `"{{ opstools_apache_config_dir }}/uchiwa.conf"`)
+
+    Path to the Apache configuration snippet for the Uchiwa proxy.
+
+- `uchiwa_path` (default: `"/uchiwa"`)
+
+    URL path at which to host Uchiwa.
+
+
+## Chrony
+
+Installs and configures an NTP client ([Chrony][]) to ensure that the
+server keeps correct time.  Clock skew between the server and clients
+can cause unexpected behaviors.
+
+[chrony]: https://chrony.tuxfamily.org/
+
+### Configuration
+
+- `chrony_package_name` (default: `"chrony"`)
+
+    The name of the Chrony package.
+
+- `chrony_service_name` (default: `"chronyd"`)
+
+    The name of the Chrony service.
+
+- `chrony_config_file` (default: `"/etc/chrony.conf"`)
+
+    Path to the Chrony configuration file.
+
+- `chrony_driftfile` (default: `"/var/lib/chrony/drift"`)
+
+    Path to the Chrony driftfile.
+
+- `chrony_logdir` (default: `"/var/log/chrony"`)
+
+    Path to the Chrony log directory.
+
+- `chrony_pools` (default: `["pool.ntp.org iburst"]`)
+
+    A list of pools to use for synchronziation.  Each item is provided'
+    directly to the `pool` command.
+
+- `chrony_default_config` (default: `["makestep 1.0 3", "rtcsync"]`)
+
+    A list of configuration items that will be included verbatim in the
+    Chrony configuration.
+
+
+# Integration with TripleO
+
+The [TripleO][] installer for OpenStack includes support for Fluentd
+and Sensu clients.  See [tripleo-integration.md][] in the `docs/`
+subdirectory of this repository.
+
+[tripleo-integration.md]: docs/tripleo-integration.md
+
+# Contributing
+
+If you encounter problems with or have suggestions about
+opstools-ansible, open an issue on our [Github issue tracker][].
+
+If you would like to contribute code, documentation, or other changes
+to the project, please read the [docs/developers.md][] document located in
+the `docs/` subdirectory of this repository.
+
+[github issue tracker]: https://github.com/centos-opstools/opstools-ansible/issues
+[developers.md]: docs/developers.md
+
+# License
+
+Copyright 2016 [Red Hat, Inc.][redhat]
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -56,4 +969,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-
+[redhat]: http://www.redhat.com/

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1,0 +1,56 @@
+# Contributing to opstools-ansible
+
+You can contribute bug fixes or enhancements to the
+[opstools-ansible][] project by [submitting a pull request][] on
+Github.
+
+[opstools-ansible]: https://github.com/centos-opstools/opstools-ansible/
+[submitting a pull request]: https://help.github.com/articles/creating-a-pull-request/
+
+## Conventions
+
+When creating or modifying Ansible roles, please use YAML format for
+module arguments as in:
+
+    - debug:
+        var: somevar
+
+Instead of the legacy format:
+
+    - debug: var=somevar
+
+We extract documentation automatically out of `defaults/main.yml` in
+each role. In order for this to work correctly, each variable in that
+file should be preceded by a comment with no intervening whitespace,
+and should be separated from other variables by one (or more) blank
+linkes, like this:
+
+    # This is some documentation.
+    some_variable: some value
+
+    # This is documentation for another_variable.
+    another_variable:
+      - this
+      - is
+      - a
+      - test
+
+## Running tests
+
+To perform some simple YAML validations, run:
+
+    tox
+
+You should do this *before* submitting pull requests.  Arranging to
+run `tox` via your local Git `pre-commit` hook will save you the
+inconvenience of submitting a pull request only to have it rejected by
+our CI testing.
+
+## Updating the documentation
+
+The role documentation in `README.md` is generated automatically from
+(a) comments in the `defaults/main.yml` file for each role and (b) a
+`README.md` included in each role.
+
+After making changes, you can regenerate the documentation by running
+`make` in the top level of the repository.

--- a/docs/footer.md
+++ b/docs/footer.md
@@ -1,0 +1,37 @@
+# Integration with TripleO
+
+The [TripleO][] installer for OpenStack includes support for Fluentd
+and Sensu clients.  See [tripleo-integration.md][] in the `docs/`
+subdirectory of this repository.
+
+[tripleo-integration.md]: docs/tripleo-integration.md
+
+# Contributing
+
+If you encounter problems with or have suggestions about
+opstools-ansible, open an issue on our [Github issue tracker][].
+
+If you would like to contribute code, documentation, or other changes
+to the project, please read the [docs/developers.md][] document located in
+the `docs/` subdirectory of this repository.
+
+[github issue tracker]: https://github.com/centos-opstools/opstools-ansible/issues
+[developers.md]: docs/developers.md
+
+# License
+
+Copyright 2016 [Red Hat, Inc.][redhat]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+- http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+[redhat]: http://www.redhat.com/

--- a/docs/header.md
+++ b/docs/header.md
@@ -1,0 +1,90 @@
+<!-- README.md is generated automatically from files and scripts in
+the docs/ directory.  If you are editing README.md directly your
+changes will be lost. -->
+
+# Overview
+
+The [opstools-ansible][] project is a collection of Ansible roles and
+playbooks that will configure an environment that provides centralized
+logging and analysis, availability monitoring, and performance
+monitoring.
+
+[tripleo]:https://wiki.openstack.org/wiki/TripleO
+[opstools-ansible]: https://github.com/larsks/opstools-ansible/
+
+# Using opstools-ansible
+
+## Before you begin
+
+Before using the opstools-ansible playbook, you will need to deploy
+one or more servers on which you will install the opstools services.
+These servers will need to be running either CentOS 7 or RHEL 7 (or a
+compatible distribution).
+
+These playbooks will install packages from a number of third-party
+repositories.  The opstools-ansible developers are unable to address
+problems with the third party packaging (other than via working around
+problems in our playbooks).
+
+## Creating an inventory file
+
+Create an Ansible inventory file `inventory/hosts` that defines your
+hosts and maps them to host groups declared in `inventory/structure`.
+For example:
+
+    server1 ansible_host=192.0.2.7 ansible_user=centos ansible_become=true
+    server2 ansible_host=192.0.2.15 ansible_user=centos ansible_become=true
+
+    [am_hosts]
+    server1
+
+    [logging_hosts]
+    server2
+
+There are two high-level groups that can be used to control service
+placement:
+
+- `am_hosts`: The playbooks will install availability monitoring
+  software (Sensu, Uchiwa, and support services) on these hosts.
+
+- `logging_hosts`: The playbooks will install the centralized logging
+  stack (Elasticsearch, Kibana, Fluentd) on these hosts.
+
+While there are more groups defined in the
+`inventory/structure` file, use of those for more granular service
+placement is neither tested nor supported at this time.
+
+## Create a configuration file
+
+Put any necessary configuration into an Ansible variables file (which
+is just a YAML document).  For example, if you wanted to enable
+logging via SSL, you would need a configuration file that looked like
+this:
+
+    fluentd_use_ssl: true
+    fluentd_shared_key: secret
+    fluentd_ca_cert: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+    fluentd_private_key:
+      -----BEGIN RSA PRIVATE KEY-----
+      ...
+      -----END RSA PRIVATE KEY-----
+
+You don't need a configuration file if you wish to use default
+options.
+
+## Run the playbook
+
+Once you have your inventory and configuration in place, you can run
+the playbook like this:
+
+    ansible-playbook playbook.yml -i inventory -e @config.yml
+
+# Roles
+
+The following documentation is automatically extracted from the
+`roles` directory in this distribution.
+
+<!-- automatically generated content will be placed here -->

--- a/docs/metadata.yml
+++ b/docs/metadata.yml
@@ -1,0 +1,3 @@
+---
+title: 'Opstools-Ansible'
+---

--- a/docs/tripleo-integration.md
+++ b/docs/tripleo-integration.md
@@ -1,0 +1,88 @@
+# Integrating opstools-ansible with a TripleO deployment
+
+## Before you begin
+
+This guide assumes that you are working with the **OpenStack
+Newton** release.
+
+For the purpose of creating some concrete examples, this document
+assumes that you have deployed your opstools-ansible environment using
+the following inventory:
+
+    ops0 ansible_host=192.168.10.10
+    ops1 ansible_host=192.168.10.20
+
+    [am_hosts]
+    ops0
+
+    [logging_hosts]
+    ops1
+
+And the following configuration:
+
+    fluentd_use_ssl: true
+    fluentd_shared_key: secret
+    fluentd_ca_cert: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+    fluentd_private_key:
+      -----BEGIN RSA PRIVATE KEY-----
+      ...
+      -----END RSA PRIVATE KEY-----
+
+### Configure TripleO
+
+Once your opstools environment is running, create a configuration file
+for your TripleO environment that will point the Sensu and Fluentd
+agents at the opstools hosts.  Look at the [logging][] and
+[monitoring][] environment files for a list of available parameters.
+
+[logging]: https://github.com/openstack/tripleo-heat-templates/blob/master/environments/logging-environment.yaml
+[monitoring]: https://github.com/openstack/tripleo-heat-templates/blob/master/environments/monitoring-environment.yaml
+
+Given the example configuration presented earlier in this document,
+you might end up with something like this (in a file we'll call
+`params.yaml`):
+
+    parameter_defaults:
+
+      LoggingServers:
+        - host: 192.168.10.20
+          port: 24284
+
+      LoggingUsesSSL: true
+
+      # This must match the fluentd_shared_key key setting you
+      # used in your Ansible configuration.
+      LoggingSharedKey: secret
+
+      # This must match the certificate you used for the
+      # fluentd_ca_cert setting in your Ansible configuration.
+      LoggingSSLCertificate: |
+        -----BEGIN CERTIFICATE-----
+        -----END CERTIFICATE-----
+
+      MonitoringRabbitHost: 192.168.10.10
+      MonitoringRabbitUsername: sensu
+      MonitoringRabbitPassword: sensu
+
+### Run overcloud deploy command
+
+Deploy your TripleO environment.  In addition to whatever command line
+options you normally use, you will need to include the
+`monitoring-environment.yaml` file (if you are configuring
+availability monitoring), and `logging-environment.yaml` file (if you
+arae configuring logging), and the `params.yaml` file described in the
+previous step.  Your `overcloud deploy` command line should look
+something like:
+
+    openackstack overcloud deploy ... \
+      -e /usr/share/openstack-tripleo-heat-templates/environments/monitoring-environment.yaml \
+      -e /usr/share/openstack-tripleo-heat-templates/environments/logging-environment.yaml \
+      -e params.yaml
+
+When the deployment completes, you should see logs appearing in Kibana
+on your opstools server (`https://192.168.10.20/kibana`) and you
+should see the results of Sensu checks in Uchiwa
+(`https://192.168.10.10/uchiwa`).

--- a/roles/chrony/README.md
+++ b/roles/chrony/README.md
@@ -1,0 +1,7 @@
+## Chrony
+
+Installs and configures an NTP client ([Chrony][]) to ensure that the
+server keeps correct time.  Clock skew between the server and clients
+can cause unexpected behaviors.
+
+[chrony]: https://chrony.tuxfamily.org/

--- a/roles/chrony/defaults/main.yml
+++ b/roles/chrony/defaults/main.yml
@@ -1,13 +1,26 @@
 ---
+# The name of the Chrony package.
 chrony_package_name: chrony
+
+# The name of the Chrony service.
 chrony_service_name: chronyd
+
+# Path to the Chrony configuration file.
 chrony_config_file: /etc/chrony.conf
+
+# Path to the Chrony driftfile.
 chrony_driftfile: /var/lib/chrony/drift
+
+# Path to the Chrony log directory.
 chrony_logdir: /var/log/chrony
 
+# A list of pools to use for synchronziation.  Each item is provided'
+# directly to the `pool` command.
 chrony_pools:
   - pool.ntp.org iburst
 
+# A list of configuration items that will be included verbatim in the
+# Chrony configuration.
 chrony_default_config:
   - 'makestep 1.0 3'
   - 'rtcsync'

--- a/roles/elasticsearch/README.md
+++ b/roles/elasticsearch/README.md
@@ -1,0 +1,6 @@
+## Elasticsearch
+
+[Elasticsearch][] is a search and analytics engine used by Ops Tools
+to collect, index, search, and analyze logs.
+
+[elasticsearch]: https://www.elastic.co/products/elasticsearch

--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -1,18 +1,36 @@
 ---
+# Name of the Elasticsearch pacakge
 elasticsearch_package_name: elasticsearch
+
+# Name of the Elasticsearch service.
 elasticsearch_service_name: elasticsearch
+
+# Path to the Elasticsearch configuration directory.
 elasticsearch_config_dir: /etc/elasticsearch
+
+# Path to the main Elasticsearch configuration file.
 elasticsearch_config_yml: '{{ elasticsearch_config_dir }}/elasticsearch.yml'
-# elasticsearch_min_mem:
-# elasticsearch_max_mem:
+
+# Values that will be set in /etc/sysconfig/elasticsearch.
 elasticsearch_sysconfig: {}
+
+# Path to Elasticsearch sysconfig file.
 elasticsearch_sysconfig_path: /etc/sysconfig/elasticsearch
+
+# Elasticsearch cluster name.
 elasticsearch_cluster_name: elasticsearch
+
+# Port on which Elasticsearch should listen.
 elasticsearch_port: 9200
+
+# Addresses on which Elasticsearch should listten.
 elasticsearch_interface:
   - 127.0.0.1
   - ::1
 
+# Configuration data for Elasticsearch.  The contents of this variable
+# will be rendered as YAML in the file referenced by
+# `elasticsearch_config_yml`.
 elasticsearch_config:
   cluster.name: '{{ elasticsearch_cluster_name }}'
   http.cors.enabled: true
@@ -20,4 +38,10 @@ elasticsearch_config:
   network.host: '{{ elasticsearch_interface }}'
   http.port: '{{ elasticsearch_port }}'
 
+# Additional configuration data for Elasticsearch.  Use this if you
+# want to add options to `elasticsearch.yml` without replacing the
+# defaults in `elasticsearch_config`.
+elasticsearch_extraconfig: {}
+
+# Name of the package that provides a Java runtime environment.
 java_package_name: java

--- a/roles/firewall/README.md
+++ b/roles/firewall/README.md
@@ -1,0 +1,4 @@
+## Firewall
+
+This role manages the system firewall using either `iptables` or
+`firewalld`.

--- a/roles/firewall/commit/README.md
+++ b/roles/firewall/commit/README.md
@@ -1,0 +1,4 @@
+## Firewall/Commit
+
+This role instantiates the firewall rules that were registered by
+other roles during the playbook run.

--- a/roles/firewall/defaults/main.yml
+++ b/roles/firewall/defaults/main.yml
@@ -1,3 +1,9 @@
 ---
+# A list of ports that should be exposed in the system firewall.
+# Roles register ports by appending them to this list using the
+# `set_fact` module.
 firewall_ports: []
+
+# Set this to False if you do not want the playbooks to make changes
+# to the system firewall.
 firewall_manage_rules: true

--- a/roles/fluentd/README.md
+++ b/roles/fluentd/README.md
@@ -1,0 +1,11 @@
+## Fluentd
+
+[Fluentd][] is a log collection tool.  It can collect logs from a
+variety of sources, filter them, and send them to a variety of
+destinations, including remote Fluentd instances.
+
+We use Fluentd to receive logs from remote Fluentd clients and deliver
+them to [Elasticsearch][].
+
+[fluentd]: http://www.fluentd.org/
+[elasticsearch]: https://www.elastic.co/products/elasticsearch

--- a/roles/fluentd/config/meta/main.yml
+++ b/roles/fluentd/config/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - fluentd

--- a/roles/fluentd/defaults/main.yml
+++ b/roles/fluentd/defaults/main.yml
@@ -1,16 +1,49 @@
 ---
+# Fluentd package name.
 fluentd_package_name: fluentd
+
+# Fluentd service name.
 fluentd_service_name: fluentd
+
+# Path to the Fluentd configuration directory.
 fluentd_config_dir: /etc/fluentd
+
+# Path to the main Fluentd configuration file.
 fluentd_config_file: '{{ fluentd_config_dir }}/fluent.conf'
+
+# Path to the directory containing Fluentd configuration snippets.
 fluentd_config_parts_dir: '{{ fluentd_config_dir }}/config.d'
+
+# User that will own Fluentd config files.
 fluentd_owner: fluentd
+
+# Group that will own Fluentd config files.
 fluentd_group: fluentd
+
+# File mode for Fluentd configuration files.
 fluentd_config_mode: 0644
+
+# A list of Fluentd plugins to install along with Fluentd.
 fluentd_plugins:
   - rubygem-fluent-plugin-secure-forward
   - rubygem-fluent-plugin-add
+
+# Set to true if Fluentd should listen for connections from remote
+# Fluentd instances.
 fluentd_listen: false
+
+# Set to true if Fluentd should use SSL.
 fluentd_use_ssl: false
+
+# Shared secret key for SSL connections.
 fluentd_shared_key:
+
+# Where to find the Fluentd server certificate authority certificate.
 fluentd_ca_cert_path: '{{ fluentd_config_dir }}/ca_cert.pem'
+
+# Content of an x509 certificate that will be used to identify the
+# server to clients.
+fluentd_ca_cert:
+
+# The key corresponding to the certificate in `fluentd_ca_cert`.
+fluentd_private_key:

--- a/roles/fluentd/elasticsearch/README.md
+++ b/roles/fluentd/elasticsearch/README.md
@@ -1,0 +1,4 @@
+## Fluentd/Elasticsearch
+
+This role contains contains configuration to send logs from Fluentd to
+an Elasticsearch instance.

--- a/roles/fluentd/elasticsearch/defaults/main.yml
+++ b/roles/fluentd/elasticsearch/defaults/main.yml
@@ -1,6 +1,16 @@
 ---
+# Address of the Elasticsearch host.
 fluentd_elasticsearch_host: localhost
+
+# Port on which Elasticsearch is accepting connections.
 fluentd_elasticsearch_port: 9200
+
+# Elasticsearch index name.
 fluentd_elasticsearch_index: fluentd
+
+# Elasticsearch index type.
 fluentd_elasticsearch_type: fluentd
+
+# Additional Fluentd configuration to apply to the Elasticsearch
+# output snippet.
 fluentd_elasticsearch_extraconfig: {}

--- a/roles/fluentd/server/README.md
+++ b/roles/fluentd/server/README.md
@@ -1,0 +1,4 @@
+## Fluentd/Server
+
+This role configures a Fluentd listener that will listen for remote
+connections from other Fluentd clients.

--- a/roles/fluentd/server/defaults/main.yml
+++ b/roles/fluentd/server/defaults/main.yml
@@ -1,5 +1,10 @@
 ---
+# A list of plugins that will be installed on the fluentd server.
 fluentd_server_plugins:
   - rubygem-fluent-plugin-elasticsearch
+
+# Path to the SSL certificate private key.
 fluentd_private_key_path: '{{ fluentd_config_dir }}/ca_key.pem'
+
+# Additional fluentd configuration.
 fluentd_server_extraconfig: {}

--- a/roles/fluentd/syslog/README.md
+++ b/roles/fluentd/syslog/README.md
@@ -1,0 +1,4 @@
+## Fluentd/Syslog
+
+This roles installs the necessary configuration to send logs from the
+local syslog server to a Fluentd instance.

--- a/roles/fluentd/syslog/defaults/main.yml
+++ b/roles/fluentd/syslog/defaults/main.yml
@@ -1,4 +1,9 @@
 ---
-fluentd_syslog_port: 5140
+# Address on which to listen for syslog messages.
 fluentd_syslog_bind_address: 127.0.0.1
+
+# Port on which to listen for syslog messages.
+fluentd_syslog_port: 5140
+
+# Fluentd tag to apply to syslog messages.
 fluentd_syslog_tag: system.messages

--- a/roles/httpd/README.md
+++ b/roles/httpd/README.md
@@ -1,0 +1,3 @@
+## Httpd
+
+This role installs the Apache web server and associated modules.

--- a/roles/httpd/defaults/main.yml
+++ b/roles/httpd/defaults/main.yml
@@ -1,11 +1,25 @@
 ---
-
+# Apache package name.
 httpd_package_name: httpd
+
+# Apache service name.
 httpd_service_name: httpd
+
+# Path to Apache top-level configuration directory.
 httpd_config_dir: /etc/httpd
+
+# Path to directory containing Apache configuration snippets.
 httpd_config_parts_dir: '{{ httpd_config_dir }}/conf.d'
+
+# Owner of Apache configuration files.
 httpd_owner: root
+
+# Group of Apache configuration files.
 httpd_group: root
+
+# Mode of Apache configuration files.
 httpd_config_mode: 0644
+
+# Modules that will be installed along with Apache.
 httpd_modules:
   - mod_ssl

--- a/roles/kibana/README.md
+++ b/roles/kibana/README.md
@@ -1,0 +1,7 @@
+## Kibana
+
+[Kibana][] is a web interface for querying an [Elasticsearch][] data
+store.
+
+[kibana]: https://www.elastic.co/products/kibana
+[elasticsearch]: https://www.elastic.co/products/elasticsearch

--- a/roles/kibana/defaults/main.yml
+++ b/roles/kibana/defaults/main.yml
@@ -1,24 +1,47 @@
 ---
+# This is the URL path at which clients can access Kibana.
 kibana_path: /kibana
-kibana_package_name: kibana
-kibana_service_name: kibana
-kibana_config_dir: /opt/kibana/config
-kibana_config_file: '{{ kibana_config_dir }}/kibana.yml'
-kibana_config_mode: 0644
-kibana_owner: kibana
-kibana_group: kibana
-kibana_elasticsearch_host: localhost
-kibana_elasticsearch_port: 9200
 
-# This is address to which Kibana should bind
-# "0.0.0.0" to allow public access
-# "localhost" to allow access through proxy only
+# The Kibana package name.
+kibana_package_name: kibana
+
+# The Kibana service name.
+kibana_service_name: kibana
+
+# Path to the Kibana configuration directory.
+kibana_config_dir: /opt/kibana/config
+
+# Path to the Kibana configuration file.
+kibana_config_file: '{{ kibana_config_dir }}/kibana.yml'
+
+# Mode for the Kibana configuration file.
+kibana_config_mode: 0644
+
+# Owner for the Kibana configuration file.
+kibana_owner: kibana
+
+# Group for the Kibana configuration file.
+kibana_group: kibana
+
+# This is address to which Kibana should bind.
+# Use "0.0.0.0" to listen on all interfaces; use "localhost" to allow
+# access from the local system only.
 kibana_server_bind: localhost
 
 # This is the address to which clients should connect to access Kibana
 # (we can't always use kibana_server_bind for that because 0.0.0.0 is
-# not an address to which we can connect)
+# not an address to which we can connect).
 kibana_server_address: '{{ kibana_server_bind }}'
+
+# The port on which Kibana should listen.
 kibana_server_port: 5601
+
+# Address of the Elasticsearch host.
+kibana_elasticsearch_host: localhost
+
+# Port on which Elasticsearch is listening.
+kibana_elasticsearch_port: 9200
+
+# URL for Kibana to contact Elasticsearch.
 kibana_server_elasticsearch_url: >-
   http://{{ kibana_elasticsearch_host }}:{{ kibana_elasticsearch_port }}

--- a/roles/kibana/proxy/README.md
+++ b/roles/kibana/proxy/README.md
@@ -1,0 +1,3 @@
+## Kibana/Proxy
+
+This role configures the Apache proxy for Kibana.

--- a/roles/kibana/proxy/defaults/main.yml
+++ b/roles/kibana/proxy/defaults/main.yml
@@ -1,9 +1,16 @@
 ---
-
-kibana_proxy_port: 80
+# The URL for the Kibana service.
 kibana_proxy_dest: 'http://{{ kibana_server_bind }}:{{ kibana_server_port }}'
+
+# Path to the htpasswd file for Kibana.
 kibana_proxy_htpasswd: /etc/httpd/conf/htpasswd-kibana
-kibana_proxy_welcome_msg: Restricted Kibana Server
+
+
+# Initial username for Kibana access to configure in the htpasswd file.
 kibana_proxy_user: operator
+
+# Initial password for Kibana access to configure in the htpasswd file.
 kibana_proxy_pass: changeme
+
+# Path to the Apache configuration file for Kibana.
 kibana_httpd_conf: '{{ opstools_apache_config_dir }}/kibana.conf'

--- a/roles/kibana/server/README.md
+++ b/roles/kibana/server/README.md
@@ -1,0 +1,4 @@
+## Kibana/Server
+
+This role installs the Kibana web application.  Configuration is taken
+from the main `kibana` role.

--- a/roles/opstoolsvhost/README.md
+++ b/roles/opstoolsvhost/README.md
@@ -1,0 +1,4 @@
+## Opstoolsvhost
+
+This role is responsible for configuring the Apache virtual host that
+will host Ops Tools services.

--- a/roles/opstoolsvhost/defaults/main.yml
+++ b/roles/opstoolsvhost/defaults/main.yml
@@ -1,11 +1,30 @@
 ---
+# Path to the Apache configuration file for the Ops Tools virtual host.
 opstools_apache_config_file: "{{ httpd_config_parts_dir }}/opstools.conf"
+
+# Path to the directory from which we will read additional
+# configuration snipps inside the OpsTools virtual host context.
 opstools_apache_config_dir: "{{ opstools_apache_config_file }}.d"
+
+# Apache SSL protocol settings.
 opstools_apache_sslprotocol: "all -SSLv2"
+
+# Apache SSL cipher suite settings.
 opstools_apache_sslciphersuite: "HIGH:MEDIUM:!aNULL:!MD5:!SEED:!IDEA"
+
+# Path to server SSL certificate.
 opstools_apache_sslcert: "/etc/pki/tls/certs/localhost.crt"
+
+# Path to SSL private key.
 opstools_apache_sslkey: "/etc/pki/tls/private/localhost.key"
+
+# Port on which to listen for HTTP connections.
 opstools_apache_http_port: 80
+
+# Port on which to listen for HTTPS connections.
 opstools_apache_https_port: 443
+
+# Path to configuration file that sets the default redirect for access
+# to the root URL (`/`).
 opstools_default_redirect_file: >-
   {{ opstools_apache_config_dir }}/default_redirect.conf

--- a/roles/prereqs/README.md
+++ b/roles/prereqs/README.md
@@ -1,0 +1,4 @@
+## Prereqs
+
+This role installs packages and configuration that are required for
+the successful operation of the opstools-ansible playbooks.

--- a/roles/prereqs/libselinuxpython/README.md
+++ b/roles/prereqs/libselinuxpython/README.md
@@ -1,0 +1,3 @@
+## Prereqs/Libselinuxpython
+
+This role installs the libselinux-python package (required by Ansible).

--- a/roles/prereqs/libselinuxpython/defaults/main.yml
+++ b/roles/prereqs/libselinuxpython/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-
+# libselinux-python package name
 libselinux_python_package_name: libselinux-python

--- a/roles/prereqs/libsemanagepython/README.md
+++ b/roles/prereqs/libsemanagepython/README.md
@@ -1,0 +1,4 @@
+## Prereqs/Libsemanagepython
+
+This role installs the libsemanage-python package (required by
+Ansible).

--- a/roles/prereqs/libsemanagepython/defaults/main.yml
+++ b/roles/prereqs/libsemanagepython/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
+# libsemanage-python package name
 libsemanage_python_package_name: libsemanage-python

--- a/roles/rabbitmq/README.md
+++ b/roles/rabbitmq/README.md
@@ -1,0 +1,7 @@
+## Rabbitmq
+
+[RabbitMQ][] is a reliable messaging service.  It is used by [Sensu][]
+agents to communicate with the Sensu server.
+
+[rabbitmq]: https://www.rabbitmq.com/
+[sensu]: https://sensuapp.org/

--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -1,14 +1,31 @@
 ---
+# Port on which RabbitMQ should listen.
 rabbitmq_port: 5672
+
+# Address to which clients should connect to the RabbitMQ service.
 rabbitmq_server: localhost
+
+# Addresses on which RabbitMQ should listen for connections.
 rabbitmq_interface:
   - "::"
 
-rabbitmq_service_name: rabbitmq-server
+# RabbitMQ package name.
 rabbitmq_package_name: rabbitmq-server
 
+# RabbitMQ service name.
+rabbitmq_service_name: rabbitmq-server
+
+# Default RabbitMQ user.
 rabbitmq_default_user: guest
+
+# Path to RabbitMQ configuration file.
 rabbitmq_config_file: /etc/rabbitmq/rabbitmq.config
+
+# Owner of RabbitMQ configuration files.
 rabbitmq_config_owner: rabbitmq
+
+# Group of RabbitMQ configuration files.
 rabbitmq_config_group: rabbitmq
+
+# Mode of RabbitMQ configuration files.
 rabbitmq_config_mode: "0644"

--- a/roles/rabbitmq/server/README.md
+++ b/roles/rabbitmq/server/README.md
@@ -1,0 +1,4 @@
+## Rabbitmq/Server
+
+This role is responsible for installing and starting the RabbitMQ
+messaging service.

--- a/roles/redis/README.md
+++ b/roles/redis/README.md
@@ -1,0 +1,8 @@
+## Redis
+
+[Redis][] is an in-memory key/value store.  [Sensu][] uses Redis as a
+data-store for storing monitoring data (e.g. a client registry,
+current check results, current monitoring events, etc).
+
+[redis]: http://redis.io/
+[sensu]: http://sensuapp.org/

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
+# Port on which Redis should listen.
 redis_listen_port: 6379
+
+# Password for accessing the Redis service.
 redis_password: kJadrW$s&5.

--- a/roles/redis/server/README.md
+++ b/roles/redis/server/README.md
@@ -1,0 +1,4 @@
+## Redis/Server
+
+This role is responsible for installing and configuring the Redis
+service.

--- a/roles/redis/server/defaults/main.yml
+++ b/roles/redis/server/defaults/main.yml
@@ -1,9 +1,16 @@
 ---
+# Path to the Redis configuration file.
 redis_config_file: /etc/redis.conf
+
+# Addresses on which Redis should listen for connections.
 redis_interface:
   - 127.0.0.1
 
+# Redis package name.
 redis_package_name: redis
+
+# Redis service name.
 redis_service_name: redis
 
+# Owner of Redis configuration files.
 redis_owner: redis

--- a/roles/repos/README.md
+++ b/roles/repos/README.md
@@ -1,0 +1,4 @@
+## Repos
+
+This role is a collection of roles for configuring additional package
+repositories.

--- a/roles/repos/opstools/README.md
+++ b/roles/repos/opstools/README.md
@@ -1,0 +1,3 @@
+## Repos/Opstools
+
+This role enables the CentOS OpsTools SIG package repository.

--- a/roles/repos/opstools/defaults/main.yml
+++ b/roles/repos/opstools/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+# URL to the CentOS OpsTools SIG repository configuration file.
 # yamllint disable-line rule:line-length
 opstools_repo_config: https://raw.githubusercontent.com/centos-opstools/centos-release-opstools/master/CentOS-OpsTools.repo

--- a/roles/repos/rdo/README.md
+++ b/roles/repos/rdo/README.md
@@ -1,0 +1,5 @@
+## Repos/Rdo
+
+This role configures access to the RDO package repository.  This role
+is only used on CentOS hosts; it will not configure RDO repositories
+on RHEL systems.

--- a/roles/repos/rdo/defaults/main.yml
+++ b/roles/repos/rdo/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
+# Specify which RDO release to use.
 rdo_release: mitaka

--- a/roles/rsyslog/README.md
+++ b/roles/rsyslog/README.md
@@ -1,0 +1,6 @@
+## Rsyslog
+
+This is a utility role for use by other roles that wish to install
+rsyslog configuration snippets.  It provides a handler that can be
+used to install rsyslogd.  This role will not install or enable
+the rsyslog service.

--- a/roles/rsyslog/defaults/main.yml
+++ b/roles/rsyslog/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
+# Path to the directory containing rsyslog configuration snippets.
 rsyslog_config_dir: /etc/rsyslog.d

--- a/roles/sensu/common/README.md
+++ b/roles/sensu/common/README.md
@@ -1,0 +1,6 @@
+## Sensu/Common
+
+[Sensu][] is a distributed monitoring solution. This role installs the
+Sensu package and performs some basic configuration tasks.
+
+[sensu]: http://sensuapp.org/

--- a/roles/sensu/common/defaults/main.yml
+++ b/roles/sensu/common/defaults/main.yml
@@ -1,16 +1,36 @@
 ---
+# Sensu package name.
 sensu_package_name: sensu
+
+# Sensu server service name.
 sensu_server_service_name: sensu-server
+
+# Sensu API service name.
 sensu_api_service_name: sensu-api
+
+# Sensu client service name.
 sensu_client_service_name: sensu-client
 
+# Path to Sensu configuration directory.
 sensu_config_path: /etc/sensu/conf.d
 
+# Owner of Sensu configuration files.
 sensu_owner: sensu
+
+# Group of Sensu configuration files.
 sensu_group: sensu
 
+# Address of RabbitMQ server to which Sensu should connect.
 sensu_rabbitmq_server: localhost
+
+# Port of the RabbitMQ server.
 sensu_rabbitmq_port: 5672
+
+# Authenticate to RabbitMQ server as this user.
 sensu_rabbitmq_user: sensu
+
+# Authenticate to RabbitMQ server with this password.
 sensu_rabbitmq_password: sensu
+
+# RabbitMQ vhost for use by Sensu.
 sensu_rabbitmq_vhost: /sensu

--- a/roles/sensu/server/README.md
+++ b/roles/sensu/server/README.md
@@ -1,0 +1,4 @@
+## Sensu/Server
+
+This role is responsible for installing and configuring the Sensu
+server.

--- a/roles/sensu/server/defaults/main.yml
+++ b/roles/sensu/server/defaults/main.yml
@@ -1,12 +1,23 @@
 ---
+# Address on which Sensu should listen for connections.
 sensu_api_bind: 0.0.0.0
+
+# Port on which Sensu should listen.
 sensu_api_port: 4567
+
+# Address to which clients should connect to contact the Sensu API.
 sensu_api_server: localhost
 
+# Address of the Redis server to which Sensu should connect.
 sensu_redis_server: 127.0.0.1
+
+# Port on which the Redis server listens.
 sensu_redis_port: '{{ redis_listen_port }}'
+
+# Password for authenticating to Redis.
 sensu_redis_password: "{{ redis_password }}"
 
+# A list of enabled Sensu checks.
 sensu_enabled_oschecks:
   - check-ceilometer_api
   - check-ceph_df
@@ -19,10 +30,19 @@ sensu_enabled_oschecks:
   - check-nova_api
   - check-nova_instance
 
+# Username for openstack checks.
 oscheck_default_username: admin
+
+# Password for openstack checks.
 oscheck_default_password: pass
+
+# Project name (aka tenant) for openstack checks.
 oscheck_default_project_name: admin
+
+# Authentication URL (Keystone server) for openstack checks.
 oscheck_default_auth_url: http://controller:5000/v2.0
+
+# Region name for openstack checks.
 oscheck_default_region_name: RegionOne
 
 oscheck_subscribers_ceilometer_api: 'overcloud-ceilometer-api'

--- a/roles/uchiwa/README.md
+++ b/roles/uchiwa/README.md
@@ -1,0 +1,7 @@
+## Uchiwa
+
+[Uchiwa][] is a web interface to [Sensu][].  This role installs and
+configures the Uchiwa service.
+
+[sensu]: http://sensuapp.org/
+[uchiwa]: https://uchiwa.io/

--- a/roles/uchiwa/defaults/main.yml
+++ b/roles/uchiwa/defaults/main.yml
@@ -1,17 +1,30 @@
 ---
+# Uchiwa package name.
 uchiwa_package_name: uchiwa
+
+# Uchiwa service name.
 uchiwa_service_name: uchiwa
 uchiwa_extra_groups:
   - sensu
 
+# Address on which Uchiwa should listen for connections.
 uchiwa_bind: 127.0.0.1
+
+# Address to which clients should connect to Uchiwa.
 uchiwa_server_address: localhost
+
+# Port on which Uchiwa should listen.
 uchiwa_port: 3000
+
+# How often Uchiwa should refresh results.
 uchiwa_refresh: 5
 
+# Path to Uchiwa configuration file.
 uchiwa_file_path: /etc/sensu/uchiwa.json
+
 uchiwa_sensu_api_server_name: uchiwa
 
+# List of Sensu datacenters to which Uchiwa should connect.
 sensu_datacenters:
   - name: "{{ uchiwa_sensu_api_server_name }}"
     host: "{{ sensu_api_server }}"

--- a/roles/uchiwa/proxy/README.md
+++ b/roles/uchiwa/proxy/README.md
@@ -1,0 +1,3 @@
+## Uchiwa/Proxy
+
+This role configures the Apache proxy for Uchiwa.

--- a/roles/uchiwa/proxy/defaults/main.yml
+++ b/roles/uchiwa/proxy/defaults/main.yml
@@ -1,9 +1,18 @@
 ---
-
-uchiwa_proxy_port: 80
+# URL for backend Uchiwa service.
 uchiwa_proxy_dest: 'http://{{ uchiwa_bind }}:{{ uchiwa_port }}'
+
+# Path to htpasswd file for controlling access to Uchiwa.
 uchiwa_proxy_htpasswd: /etc/httpd/conf/htpasswd-uchiwa
+
+# User to create in htpasswd file.
 uchiwa_proxy_user: operator
+
+# Password for user in htpasswd file.
 uchiwa_proxy_pass: changeme
+
+# Path to the Apache configuration snippet for the Uchiwa proxy.
 uchiwa_httpd_conf: '{{ opstools_apache_config_dir }}/uchiwa.conf'
+
+# URL path at which to host Uchiwa.
 uchiwa_path: /uchiwa

--- a/tools/extract-role-docs.py
+++ b/tools/extract-role-docs.py
@@ -1,0 +1,67 @@
+from cStringIO import StringIO
+from parser import HashCommentParser
+import argparse
+import os
+import sys
+import textwrap
+import yaml
+import json
+
+def generate_docs(roles, output=sys.stdout):
+    for dirpath, dirnames, filenames in os.walk(roles):
+        for keydir in ['meta', 'tasks', 'defaults']:
+            if keydir in dirnames:
+                break
+        else:
+            continue
+
+        README = os.path.join(dirpath, 'README.md')
+        DEFAULTS = os.path.join(dirpath, 'defaults', 'main.yml')
+
+        if os.path.isfile(README):
+            with open(README, 'r') as fd:
+                output.write(fd.read())
+
+        if os.path.isfile(DEFAULTS):
+            output.write('\n')
+            output.write('### Configuration')
+            output.write('\n\n')
+
+            with open(DEFAULTS) as fd:
+                parser = HashCommentParser(fd)
+                for codeblock, doc in parser:
+                    codebuf = StringIO('\n'.join(codeblock))
+                    code = yaml.load(codebuf)
+
+                    if not isinstance(code, dict):
+                        continue
+
+                    varname, varval = code.items()[0]
+
+                    output.write('- `{}` (default: `{}`)'.format(
+                        varname, json.dumps(varval)))
+                    output.write('\n\n')
+
+                    # This prints out the lines of the doc chunk indented
+                    # by four spaces.  This should allow us to format
+                    # multi-paragraph documentation chunks correctly.
+                    output.write('\n'.join('    %s' % line.rstrip()
+                                           for line in doc))
+                    output.write('\n\n')
+
+        output.write('\n')
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument('--roles', '-r', default='roles')
+    p.add_argument('--output', '-o', default='-')
+    return p.parse_args()
+
+def main():
+    args = parse_args()
+
+    with sys.stdout if args.output == '-' else open(args.output, 'w') as fd:
+        generate_docs(args.roles, output=fd)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/parser.py
+++ b/tools/parser.py
@@ -1,0 +1,65 @@
+# This class is responsible for transforming a file containing a mix
+# of code and documentation into a set of `(code, documentation)`
+# pairs.
+class HashCommentParser(object):
+    def __init__(self, fd):
+        self.fd = fd
+
+    # This class is an iterator, which means that after you do this:
+    #
+    #     with open('somefile') as fd:
+    #         doc = HashCommentParser(fd)
+    #
+    # You can then iterate over `(code, documentation)` chunks
+    # like this:
+    #
+    #         for codepart, docpart in doc:
+    #             ...
+    def __iter__(self):
+        return self.iter_chunks()
+
+    def iter_chunks(self):
+        doc = []
+        code = []
+        indoc = False
+
+        # Iterate over lines in the input file looking for
+        # documentation (lines that start with `# `, preceded
+        # by an arbitrary amount of whitespace).
+        for line in self.fd:
+            stripped = line.lstrip()
+
+            # Rules for when we are already reading
+            # a block of documentation.
+            if indoc:
+                if stripped.startswith('# '):
+                    doc.append(stripped[2:])
+                    continue
+                elif stripped == '#\n':
+                    doc.append('\n')
+                    continue
+                else:
+                    indoc = False
+
+            # Rules for when we think we are reading code.
+            if not indoc:
+                if stripped.startswith('# '):
+                    # It looks like we're starting a new documentation
+                    # chunk! If we have either an existing code or doc
+                    # chunk, we should yield a pair back to the caller
+                    # before starting to accumulate the new
+                    # documentation.
+                    if code or doc:
+                        yield (code, doc)
+                        code = []
+                        doc = []
+
+                    indoc = True
+                    doc.append(stripped[2:])
+                elif not stripped and not code:
+                    continue
+                else:
+                    code.append(line)
+
+        # Yield remaining blocks back to caller.
+        yield (code, doc)


### PR DESCRIPTION
This patch adds inline documentation to all (well, most) of the
`defaults/main.yml` files in our Ansible roles.  It also includes
tools for generating `README.md` by extracting this documentation and
combining it with static content.

The tools and static content are located in the `docs/` directory.
