### PR TITLE
Enable to set firewall rule protocol

### DIFF
--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -38,5 +38,10 @@
 
 - name: Register elasticsearch firewall ports
   set_fact:
-    firewall_ports: >
-      {{ firewall_ports + [elasticsearch_port] }}
+    firewall_data: >
+      {{ firewall_data }} + [
+        {
+          'port': "{{ elasticsearch_port }}",
+          'protocol': 'tcp'
+        }
+      ]

--- a/roles/firewall/commit/tasks/main.yml
+++ b/roles/firewall/commit/tasks/main.yml
@@ -2,19 +2,19 @@
 - name: Enable service ports via iptables
   iptables:
       chain: INPUT
-      protocol: tcp
-      destination_port: "{{ item }}"
+      protocol: "{{ item.protocol }}"
+      destination_port: "{{ item.port }}"
       jump: ACCEPT
-  with_items: '{{ firewall_ports }}'
+  with_items: '{{ firewall_data }}'
   when: firewall_manage_rules and firewall_use_iptables
   notify: persist iptables
 
 - name: Enable service ports via firewalld
   firewalld:
-      port: "{{ item }}/tcp"
+      port: "{{ item.port }}/{{ item.protocol }}"
       zone: public
       permanent: true
       state: enabled
-  with_items: '{{ firewall_ports }}'
+  with_items: '{{ firewall_data }}'
   when: firewall_manage_rules and firewall_use_firewalld
   notify: reload firewalld

--- a/roles/firewall/defaults/main.yml
+++ b/roles/firewall/defaults/main.yml
@@ -2,7 +2,7 @@
 # A list of ports that should be exposed in the system firewall.
 # Roles register ports by appending them to this list using the
 # `set_fact` module.
-firewall_ports: []
+firewall_data: []
 
 # Set this to False if you do not want the playbooks to make changes
 # to the system firewall.

--- a/roles/fluentd/server/tasks/main.yml
+++ b/roles/fluentd/server/tasks/main.yml
@@ -46,7 +46,16 @@
     mode: '0400'
   when: fluentd_use_ssl
 
-- name: register fluentd firewal ports
+- name: Register fluentd firewal ports
   set_fact:
-    firewall_ports: >
-      {{ firewall_ports + [fluentd_port] }}
+    firewall_data: >
+      {{ firewall_data }} + [
+        {
+          'port': "{{ fluentd_port }}",
+          'protocol': 'tcp'
+        },
+        {
+          'port': "{{ fluentd_port }}",
+          'protocol': 'udp'
+        }
+      ]

--- a/roles/grafana/tasks/grafana.yml
+++ b/roles/grafana/tasks/grafana.yml
@@ -32,5 +32,10 @@
 
 - name: Insert firewalld rule for grafana
   set_fact:
-    firewall_ports: >
-      {{ firewall_ports + [grafana_port] }}
+    firewall_data: >
+      {{ firewall_data }} + [
+        {
+          'port': "{{ grafana_port }}",
+          'protocol': 'tcp'
+        }
+      ]

--- a/roles/grafana/tasks/graphite.yml
+++ b/roles/grafana/tasks/graphite.yml
@@ -49,5 +49,10 @@
 
 - name: Insert firewalld rule for graphite
   set_fact:
-    firewall_ports: >
-      {{ firewall_ports + [graphite_listen_port] }}
+    firewall_data: >
+      {{ firewall_data }} + [
+        {
+          'port': "{{ graphite_listen_port }}",
+          'protocol': 'tcp'
+        }
+      ]

--- a/roles/opstoolsvhost/tasks/main.yml
+++ b/roles/opstoolsvhost/tasks/main.yml
@@ -12,10 +12,16 @@
     mode: "0644"
   notify: restart httpd
 
-- name: Register apache firewall  ports
+- name: Register apache firewall ports
   set_fact:
-    firewall_ports: >
-      {{ firewall_ports + [item] }}
-  with_items:
-    - '{{ opstools_apache_http_port }}'
-    - '{{ opstools_apache_https_port }}'
+    firewall_data: >
+      {{ firewall_data }} + [
+        {
+          'port': "{{ opstools_apache_http_port }}",
+          'protocol': 'tcp'
+        },
+        {
+          'port': "{{ opstools_apache_https_port }}",
+          'protocol': 'tcp'
+        }
+      ]

--- a/roles/rabbitmq/server/tasks/main.yml
+++ b/roles/rabbitmq/server/tasks/main.yml
@@ -35,6 +35,11 @@
 
 - name: Register rabbitmq firewall ports
   set_fact:
-    firewall_ports: >
-      {{ firewall_ports + [item.port|default(rabbitmq_port)] }}
+    firewall_data: >
+      {{ firewall_data }} + [
+        {
+          'port': "{{ item.port|default(rabbitmq_port) }}",
+          'protocol': 'tcp'
+        }
+      ]
   with_items: '{{ rabbitmq_interface }}'

--- a/roles/redis/server/tasks/main.yml
+++ b/roles/redis/server/tasks/main.yml
@@ -40,7 +40,12 @@
     enabled: yes
   when: manage_services|default(false)
 
-- name: register redis firewall  port
+- name: Register redis firewall port
   set_fact:
-    firewall_ports: >
-      {{ firewall_ports + [redis_listen_port] }}
+    firewall_data: >
+      {{ firewall_data }} + [
+        {
+          'port': "{{ redis_listen_port }}",
+          'protocol': 'tcp'
+        }
+      ]

--- a/roles/uchiwa/tasks/main.yml
+++ b/roles/uchiwa/tasks/main.yml
@@ -26,5 +26,10 @@
 
 - name: Register uchiwa firewal ports
   set_fact:
-    firewall_ports: >
-      {{ firewall_ports + [ uchiwa_port ] }}
+    firewall_data: >
+      {{ firewall_data }} + [
+        {
+          'port': "{{ uchiwa_port }}",
+          'protocol': 'tcp'
+        }
+      ]


### PR DESCRIPTION
This patch starts series of patches of firewall refactor and contains
following changes:
  - continues with task name unification
  - adds support for port setting in firewall rules