### PR TITLE
Capitalize chrony handler

### DIFF
--- a/roles/chrony/handlers/main.yml
+++ b/roles/chrony/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart chronyd
+- name: Restart chronyd
   service:
     name: '{{ chrony_service_name }}'
     state: restarted


### PR DESCRIPTION
It is a fix for the following error:
TASK [chrony : Generate chrony configuration] **********************************
ERROR! The requested handler 'Restart chronyd' was not found in any of the known handlers
