### PR TITLE
increase check intervals for potentially slow operations

### DIFF
--- a/roles/sensu/server/templates/sensu_oscheck-check-cinder_volume.json.j2
+++ b/roles/sensu/server/templates/sensu_oscheck-check-cinder_volume.json.j2
@@ -1,5 +1,5 @@
 "oschecks-check_cinder_volume": {
             "command": "/usr/libexec/openstack-monitoring/checks/oschecks-check_cinder_volume --username :::openstack.username|{{ oscheck_default_username }}::: --password :::openstack.password|{{ oscheck_default_password }}::: --auth_url :::openstack.auth_url|{{ oscheck_default_auth_url }}::: --tenant :::openstack.tenant_name|{{ oscheck_default_username }}:::",
             "subscribers": ["{{ oscheck_subscribers_cinder_volume }}"],
-            "interval": 60
+            "interval": 900
         }

--- a/roles/sensu/server/templates/sensu_oscheck-check-nova_instance.json.j2
+++ b/roles/sensu/server/templates/sensu_oscheck-check-nova_instance.json.j2
@@ -1,5 +1,5 @@
  "oschecks-check_nova_instance": {
             "command": "/usr/libexec/openstack-monitoring/checks/oschecks-check_nova_instance {{ os_auth_args }}",
             "subscribers": ["{{ oscheck_subscribers_nova_instance }}"],
-            "interval": 60
+            "interval": 900
         }


### PR DESCRIPTION
this increases the default interval for the cinder create-volume and
the nova create-server checks.