### PR TITLE
Update centos-opstools.repo

### DIFF
--- a/roles/repos/opstools/files/centos-opstools.repo
+++ b/roles/repos/opstools/files/centos-opstools.repo
@@ -7,11 +7,10 @@
 name=CentOS-7 - OpsTools - testing repo
 baseurl=http://buildlogs.centos.org/centos/7/opstools/$basearch/
 gpgcheck=0
-enabled=1
-#gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-OpsTools
-#
-[centos-opstools-logging]
-name=CentOS-7 - OpsTools - logging testing repo
-baseurl=http://cbs.centos.org/repos/opstools7-elastic-common-testing/$basearch/os/
+enabled=0
+
+[centos-release-opstools]
+name=CentOS-7 - OpsTools - release
+baseurl=http://mirror.centos.org/centos/7/opstools/$basearch/
 gpgcheck=0
 enabled=1


### PR DESCRIPTION
The current repo file points to an old location resulting in out of date packages - e.g. Sensu