### PR TITLE
Monitor cinder-volume in case of pacemaker

### DIFF
--- a/roles/sensu/server/templates/sensu-check-cinder-volume.json.j2
+++ b/roles/sensu/server/templates/sensu-check-cinder-volume.json.j2
@@ -1,0 +1,6 @@
+"check-cinder-volume": {
+    "command": "systemctl is-enabled openstack-cinder-volume && systemctl is-active openstack-cinder-volume || /usr/bin/sudo /usr/libexec/openstack-monitoring/checks/oschecks-pacemaker_host_check -r openstack-cinder-volume",
+    "subscribers": {{ check.subscribers|default(["overcloud-" + check.name])|to_json }}, 
+    "interval": {{ check.interval|default(60) }}
+
+}


### PR DESCRIPTION
cinder-volume can be a systemd service or a pacemaker resource. In the
playbook, it was only check as systemd service. With this change, it
check if it's a service or a pacemaker resource. Following #80 cinder notice.

Warning: in case of pacemaker resource, a sudo rule must be add where
cinder is subscribed as folowing:

/etc/sudoers.d/sensu
```
Defaults:sensu !requiretty

sensu ALL = (root) NOPASSWD:
/usr/libexec/openstack-monitoring/checks/oschecks-pacemaker_host_check
-r *
```

Tested and works over a RHOSP 10 deployment.

Signed-off-by: Cyril Lopez <cylopez@redhat.com>