### PR TITLE
Add check on pcs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ This role is responsible for installing and configuring the Sensu.
           subscribers:
             - overcloud-ceilometer-aodh-api
     
+- `sensu_overcloud_checks_pcs`
+
+    A list of Sensu checks that will run on the overcloud hosts. Used
+    for pcs resources.
 
 - `sensu_remote_checks` (default: `[]`)
 

--- a/roles/sensu/defaults/main.yml
+++ b/roles/sensu/defaults/main.yml
@@ -164,6 +164,15 @@ sensu_overcloud_checks:
     service: pacemaker
   - name: swift-proxy
 
+# A list of sensu checks for service managed as resources in pacemaker
+sensu_overcloud_checks_pcs:
+  - name: rabbitmq-clone
+    subscribers:
+      - overcloud-rabbitmq
+  - name: galera
+    subscribers:
+      - overcloud-galera
+
 # A list of sensu checks that will run on an opstools server
 sensu_remote_checks: []
 

--- a/roles/sensu/server/templates/sensu-check-pcs.json.j2
+++ b/roles/sensu/server/templates/sensu-check-pcs.json.j2
@@ -1,0 +1,5 @@
+"check-pcs-{{ check.name }}": {
+    "command": "/usr/bin/sudo /usr/libexec/openstack-monitoring/checks/oschecks-pacemaker_host_check -r {{ check.name }}",
+    "subscribers": {{ check.subscribers|default([sensu_client_subscription])|to_json }},
+    "interval": {{ check.interval|default(60) }}
+}

--- a/roles/sensu/server/templates/sensu-checks.json.j2
+++ b/roles/sensu/server/templates/sensu-checks.json.j2
@@ -8,6 +8,13 @@
     "sensu-check-systemd.json.j2"
 ] %}
 {% endfor %}
+{% for check in sensu_overcloud_checks_pcs %}
+{{ comma() }}
+{% include [
+    "sensu-check-" + check.name + ".json.j2",
+    "sensu-check-pcs.json.j2"
+] %}
+{% endfor %}
 {% for check in sensu_remote_checks %}
 {{ comma() }}
 {% include [


### PR DESCRIPTION
In RDO implementation, some service are setup as pacemaker resource. I
add a variable sensu_overcloud_checks_pcs to setup check.

Warning: Is needed to setup a sensu as sudo user.

/etc/sudoers.d/sensu
```
Defaults:sensu !requiretty

sensu ALL = (root) NOPASSWD:
/usr/libexec/openstack-monitoring/checks/oschecks-pacemaker_host_check
-r *
```

Tested and works on RHOSP 10.

Signed-off-by: Cyril Lopez <cylopez@redhat.com>