### PR TITLE
Allow for install on systems with selinux disabled

### DIFF
--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -17,6 +17,7 @@
     name: httpd_can_network_connect
     state: yes
     persistent: yes
+  when: ansible_selinux.status != "disabled"
 
 - name: Ensure httpd configuration directory exists
   file:


### PR DESCRIPTION

This change should allow for the ansible playbook to be run against systems that have selinux disabled.
