### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,14 +185,6 @@ Configuration
 
     Path to htpasswd file for controlling access to Uchiwa.
 
-- `uchiwa_proxy_user` (default: `"operator"`)
-
-    User to create in htpasswd file.
-
-- `uchiwa_proxy_pass` (default: `"changeme"`)
-
-    Password for user in htpasswd file.
-
 - `uchiwa_httpd_conf` (default: `"{{ opstools_apache_config_dir }}/uchiwa.conf"`)
 
     Path to the Apache configuration snippet for the Uchiwa proxy.
@@ -200,8 +192,10 @@ Configuration
 - `uchiwa_path` (default: `"/uchiwa"`)
 
     URL path at which to host Uchiwa.
+    
+- `uchiwa_credentials` (default: `["username": "operator", "password": "changeme"`])
 
-
+   List of Users and Passwords to create in htpasswd file
 
 Sensu
 -----


### PR DESCRIPTION
There was a change to uchiwa playbooks on  made on April 28th made by dmsimard  on how users and passwords are being created for uchiwa service.
This doc update reflects new parameters and removed the old one that are no longer valid.