### PR TITLE
Changed package name for MariaDB Galera

### DIFF
--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -4,7 +4,7 @@ database_host: '127.0.0.1'
 
 # database packages
 database_packages:
-  - mariadb-server-galera
+  - mariadb-galera-server
   - MySQL-python
 
 # database service name


### PR DESCRIPTION
in file: roles/mariadb/defaults/main.yml
from: mariadb-server-galera
to: mariadb-galera-server

I think the 'to' name is correct, the 'from' package does not exists.
At least the playbook applies correctly.

-Derik.

