### PR TITLE
grafana: fix gnocchi datasource config

### DIFF
--- a/roles/grafana/proxy/templates/data_source.json.j2
+++ b/roles/grafana/proxy/templates/data_source.json.j2
@@ -3,13 +3,15 @@
   "name": "gnocchi",
   "type":"gnocchixyz-gnocchi-datasource",
   "url":"http://{{ansible_host}}:8041",
-  "jsonData": { "mode": "noauth", "username":"admin"},
+  "basicAuth":true,
+  "basicAuthUser": "admin",
+  "basicAuthPassword": "notused",
   {% else %}
+  "basicAuth":false,
   "name": "graphite",
   "type":"graphite",
   "url":"http://localhost:{{graphite_listen_port}}/",
   {% endif %}
   "access":"proxy",
-  "isDefault":true,
-  "basicAuth":false
+  "isDefault":true
 }


### PR DESCRIPTION
Grafana should use Basic Auth instead of noauth for Gnocchi.

Change-Id: Ib08f4aa13b10a3c71c3522ea08372527573f31cc